### PR TITLE
add Tilt check

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  GO_VERSION: '1.18'
+
 jobs:
   chart-lint:
     name: Helm chart Lint
@@ -51,7 +54,7 @@ jobs:
       - uses: actions/setup-go@v2
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          go-version: '1.18'
+          go-version: ${{ env.GO_VERSION }}
       - name: Create image for chart testing
         if: steps.list-changed.outputs.changed == 'true'
         run: |
@@ -67,15 +70,39 @@ jobs:
       #  if: steps.list-changed.outputs.changed == 'true'
       #  run: ct install --namespace ct --config .github/ct.yaml --debug --upgrade
 
-  test:
+  tilt:
+    name: Check testing environment 
+    runs-on: ubuntu-latest
+    # If the environment is broken this job could timeout since the default timeout for tilt ci is 30m.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.6.0
+        with:
+          minikube version: 'v1.26.0'
+          kubernetes version: 'v1.24.0'
+          # default driver doesn't support 'eval $$(minikube docker-env)'.
+          driver: docker
+          github token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install Tilt
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
+      - name: Run Tilt ci
+        run: |
+          make tilt-ci
 
+  test:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/cache@v3
         with:
           path: |

--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,10 @@ local-env-start:
 
 .PHONY: tilt-up
 tilt-up:
-	eval $$(minikube docker-env); tilt up ; tilt down
+	eval $$(minikube docker-env) && tilt up ; tilt down
+
+.PHONY: tilt-ci
+tilt-ci:
+	helm repo add newrelic https://helm-charts.newrelic.com
+	helm dependency update ./charts/newrelic-prometheus
+	eval $$(minikube docker-env) && tilt ci


### PR DESCRIPTION
Adding a CI job to check that the development environment does not brakes.

Based on [tilt ci](https://docs.tilt.dev/ci.html). 

Based on top of `feat/remote-write-chart-config` since now is broken on master.