### PR TITLE
Modified bool values for bool pointers to ensure always the defaults.

### DIFF
--- a/configurator/input_test.go
+++ b/configurator/input_test.go
@@ -36,6 +36,9 @@ func checkInput(t *testing.T, expected Input, inputData []byte) {
 func testInputExpectation(t *testing.T) Input {
 	t.Helper()
 
+	trueValue := true
+	falseValue := false
+
 	return Input{
 		Common: promcfg.GlobalConfig{
 			ScrapeInterval: time.Second * 60,
@@ -51,7 +54,7 @@ func testInputExpectation(t *testing.T) Input {
 			Staging:    true,
 			ProxyURL:   "http://proxy.url.to.use:1234",
 			TLSConfig: &promcfg.TLSConfig{
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: &trueValue,
 				CAFile:             "/path/to/ca.crt",
 				CertFile:           "/path/to/cert.crt",
 				KeyFile:            "/path/to/key.crt",
@@ -66,7 +69,7 @@ func testInputExpectation(t *testing.T) Input {
 				BatchSendDeadLine: 5 * time.Second,
 				MinBackoff:        30 * time.Millisecond,
 				MaxBackoff:        5 * time.Second,
-				RetryOnHTTP429:    false,
+				RetryOnHTTP429:    &falseValue,
 			},
 			RemoteTimeout: 30 * time.Second,
 			ExtraWriteRelabelConfigs: []promcfg.RelabelConfig{

--- a/configurator/promcfg/config.go
+++ b/configurator/promcfg/config.go
@@ -16,7 +16,7 @@ type TLSConfig struct {
 	CertFile           string `yaml:"cert_file,omitempty" json:"cert_file,omitempty"`
 	KeyFile            string `yaml:"key_file,omitempty" json:"key_file,omitempty"`
 	ServerName         string `yaml:"server_name,omitempty" json:"server_name,omitempty"`
-	InsecureSkipVerify bool   `yaml:"insecure_skip_verify" json:"insecure_skip_verify"`
+	InsecureSkipVerify *bool  `yaml:"insecure_skip_verify" json:"insecure_skip_verify"`
 	MinVersion         string `yaml:"min_version,omitempty" json:"min_version,omitempty"`
 }
 
@@ -49,7 +49,7 @@ type OAuth2 struct {
 // Job holds fields which do not change from input and output jobs.
 type Job struct {
 	JobName               string           `yaml:"job_name"`
-	HonorLabels           bool             `yaml:"honor_labels,omitempty"`
+	HonorLabels           *bool            `yaml:"honor_labels,omitempty"`
 	HonorTimestamps       *bool            `yaml:"honor_timestamps,omitempty"`
 	Params                url.Values       `yaml:"params,omitempty"`
 	Scheme                string           `yaml:"scheme,omitempty"`
@@ -136,7 +136,7 @@ type QueueConfig struct {
 	BatchSendDeadLine time.Duration `yaml:"batch_send_deadline"`
 	MinBackoff        time.Duration `yaml:"min_backoff"`
 	MaxBackoff        time.Duration `yaml:"max_backoff"`
-	RetryOnHTTP429    bool          `yaml:"retry_on_http_429"`
+	RetryOnHTTP429    *bool         `yaml:"retry_on_http_429"`
 }
 
 // RemoteWrite represents a prometheus remote_write config.

--- a/configurator/remotewrite/config_test.go
+++ b/configurator/remotewrite/config_test.go
@@ -21,6 +21,8 @@ func TestBuildRemoteWriteOutput(t *testing.T) {
 		dataSourceName string
 	}
 
+	trueValue := true
+
 	cases := []struct {
 		Name     string
 		Input    args
@@ -53,7 +55,7 @@ func TestBuildRemoteWriteOutput(t *testing.T) {
 						CertFile:           "cert-file",
 						KeyFile:            "key-file",
 						ServerName:         "server.name",
-						InsecureSkipVerify: true,
+						InsecureSkipVerify: &trueValue,
 						MinVersion:         "TLS12",
 					},
 					QueueConfig: &promcfg.QueueConfig{
@@ -64,7 +66,7 @@ func TestBuildRemoteWriteOutput(t *testing.T) {
 						BatchSendDeadLine: time.Second,
 						MinBackoff:        100 * time.Microsecond,
 						MaxBackoff:        time.Second,
-						RetryOnHTTP429:    true,
+						RetryOnHTTP429:    &trueValue,
 					},
 					RemoteTimeout: 10 * time.Second,
 					ExtraWriteRelabelConfigs: []promcfg.RelabelConfig{
@@ -88,7 +90,7 @@ func TestBuildRemoteWriteOutput(t *testing.T) {
 					CertFile:           "cert-file",
 					KeyFile:            "key-file",
 					ServerName:         "server.name",
-					InsecureSkipVerify: true,
+					InsecureSkipVerify: &trueValue,
 					MinVersion:         "TLS12",
 				},
 				QueueConfig: &promcfg.QueueConfig{
@@ -99,7 +101,7 @@ func TestBuildRemoteWriteOutput(t *testing.T) {
 					BatchSendDeadLine: time.Second,
 					MinBackoff:        100 * time.Microsecond,
 					MaxBackoff:        time.Second,
-					RetryOnHTTP429:    true,
+					RetryOnHTTP429:    &trueValue,
 				},
 				WriteRelabelConfigs: []promcfg.RelabelConfig{
 					{

--- a/configurator/statictargets/config_test.go
+++ b/configurator/statictargets/config_test.go
@@ -31,7 +31,7 @@ func TestBuildStaticTargetsOutput(t *testing.T) {
 					{
 						PromScrapeJob: promcfg.Job{
 							JobName:               "fancy-job",
-							HonorLabels:           true,
+							HonorLabels:           &trueValue,
 							HonorTimestamps:       &trueValue,
 							Params:                url.Values{"q": {"puppies"}, "oe": {"utf8"}},
 							Scheme:                "https",
@@ -49,7 +49,7 @@ func TestBuildStaticTargetsOutput(t *testing.T) {
 								CertFile:           "cert-file",
 								KeyFile:            "key-file",
 								ServerName:         "server.name",
-								InsecureSkipVerify: true,
+								InsecureSkipVerify: &trueValue,
 								MinVersion:         "TLS12",
 							},
 							BasicAuth: nil,
@@ -70,7 +70,7 @@ func TestBuildStaticTargetsOutput(t *testing.T) {
 									CertFile:           "cert-file",
 									KeyFile:            "key-file",
 									ServerName:         "server.name",
-									InsecureSkipVerify: true,
+									InsecureSkipVerify: &trueValue,
 									MinVersion:         "TLS12",
 								},
 								ProxyURL: "",
@@ -98,7 +98,7 @@ func TestBuildStaticTargetsOutput(t *testing.T) {
 			Expected: []promcfg.Job{
 				{
 					JobName:               "fancy-job",
-					HonorLabels:           true,
+					HonorLabels:           &trueValue,
 					HonorTimestamps:       &trueValue,
 					Params:                url.Values{"q": {"puppies"}, "oe": {"utf8"}},
 					Scheme:                "https",
@@ -116,7 +116,7 @@ func TestBuildStaticTargetsOutput(t *testing.T) {
 						CertFile:           "cert-file",
 						KeyFile:            "key-file",
 						ServerName:         "server.name",
-						InsecureSkipVerify: true,
+						InsecureSkipVerify: &trueValue,
 						MinVersion:         "TLS12",
 					},
 					BasicAuth: nil,
@@ -137,7 +137,7 @@ func TestBuildStaticTargetsOutput(t *testing.T) {
 							CertFile:           "cert-file",
 							KeyFile:            "key-file",
 							ServerName:         "server.name",
-							InsecureSkipVerify: true,
+							InsecureSkipVerify: &trueValue,
 							MinVersion:         "TLS12",
 						},
 						ProxyURL: "",


### PR DESCRIPTION
- We have made all bool values become pointers to boolean, in order to make the empty value to be nil, so both if the flag default is true or false, it will be printed in the configuration when noted by the user but if not the config file will skip this flag.