### PR TITLE
fix(proxy): closing connection

### DIFF
--- a/test/integration/mocks/remote_write.go
+++ b/test/integration/mocks/remote_write.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -10,14 +11,14 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
-
-	"golang.org/x/sync/errgroup"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 // StartRemoteWriteEndpoint start an remote write endpoint with proxy.
@@ -79,17 +80,14 @@ func pipe(from net.Conn, to net.Conn) error {
 	defer from.Close()
 
 	_, err := io.Copy(from, to)
-	if err == nil {
+	switch {
+	case err == nil:
 		return nil
-	}
-
-	if pipeErrCanBeIgnored(err) {
+	case errors.Is(err, net.ErrClosed):
 		return nil
+	case errors.Is(err, syscall.ECONNRESET):
+		return nil
+	default:
+		return fmt.Errorf("error in pipe: %w", err)
 	}
-
-	return fmt.Errorf("error in pipe: %w", err)
-}
-
-func pipeErrCanBeIgnored(err error) bool {
-	return strings.Contains(err.Error(), "closed network") || strings.Contains(err.Error(), "connection reset by peer")
 }


### PR DESCRIPTION
It is related to https://github.com/newrelic-forks/newrelic-prometheus/issues/34 . Not sure still that that was the root cause of all flakiness

When interrupting the Prometheus server the pipe was sometimes closed abruptly. The tests were passing fine, but releasing the resources from time to time a failure was detected.

We do not care about that error since it is in the shutdown of the proxy after the tests run.