### PR TITLE
Remove sharding endpoints unused label

### DIFF
--- a/configurator/builder.go
+++ b/configurator/builder.go
@@ -91,11 +91,16 @@ func validate(config *Input) error {
 }
 
 // getIndexFromDataSourceName returns the corresponding shard index from the DataSourceNameEnvKey env var.
+// This function assumes the name follows the k8s name convention being `-` separated.
+// E.g. by running two shards the pod names will be the following:
+//
+//	1: newrelic-prometheus-0
+//	2: newrelic-prometheus-1
 func getIndexFromDataSourceName(dataSourceName string) string {
 	parts := strings.Split(dataSourceName, "-")
-	if len(parts) < 3 { //nolint: gomnd
+	if len(parts) <= 1 {
 		return ""
 	}
 
-	return parts[2]
+	return parts[len(parts)-1]
 }

--- a/configurator/sharding/sharding_test.go
+++ b/configurator/sharding/sharding_test.go
@@ -30,33 +30,7 @@ func TestConfig_IncludeShardingRules(t *testing.T) {
 			},
 		},
 		{
-			name: "AddingStaticTargetsRules",
-			config: sharding.Config{
-				Kind:             "hash",
-				TotalShardsCount: 2,
-				ShardIndex:       "1",
-			},
-			job: promcfg.Job{},
-			expectedRelabelConfigs: []promcfg.RelabelConfig{
-				{
-					SourceLabels: []string{"__address__"},
-					Modulus:      2,
-					Action:       "hashmod",
-					TargetLabel:  "__tmp_hash",
-				},
-				{
-					SourceLabels: []string{"__tmp_hash"},
-					Regex:        "^1$",
-					Action:       "keep",
-				},
-			},
-			assert: func(t *testing.T, job promcfg.Job, expectedRelabelConfigs []promcfg.RelabelConfig) {
-				t.Helper()
-				assert.Equal(t, expectedRelabelConfigs, job.RelabelConfigs)
-			},
-		},
-		{
-			name: "Addingk8sEndpointsRules",
+			name: "AddingShardingRules",
 			config: sharding.Config{
 				Kind:             "hash",
 				TotalShardsCount: 2,
@@ -71,7 +45,7 @@ func TestConfig_IncludeShardingRules(t *testing.T) {
 			},
 			expectedRelabelConfigs: []promcfg.RelabelConfig{
 				{
-					SourceLabels: []string{"__address__", "_meta_kubernetes_service_name"},
+					SourceLabels: []string{"__address__"},
 					Modulus:      2,
 					Action:       "hashmod",
 					TargetLabel:  "__tmp_hash",

--- a/configurator/testdata/sharding-test.expected.yaml
+++ b/configurator/testdata/sharding-test.expected.yaml
@@ -70,7 +70,7 @@ scrape_configs:
     kubernetes_sd_configs:
       - role: endpoints
     relabel_configs:
-      - source_labels: [ '__address__', '_meta_kubernetes_service_name' ]
+      - source_labels: [ '__address__' ]
         modulus: 2
         action: hashmod
         target_label: __tmp_hash


### PR DESCRIPTION
Remove `_meta_kubernetes_service_name` label from sharding endpoint relabeling. It was used for the load test and it's not necessary. I've checked as well the [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator/blob/e086b335f30a422f7659e08abda898fc58c780bb/pkg/prometheus/promcfg.go#L1460) that confirms this.

### Bonus

- Improved `getIndexFromDataSourceName` logic consistency.
