### PR TITLE
move `data_source_name` inside `newrelic_remote_write`

### DIFF
--- a/internal/configurator/builder.go
+++ b/internal/configurator/builder.go
@@ -28,7 +28,7 @@ func BuildPromConfig(nrConfig *NrConfig) (*PromConfig, error) {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	remoteWrite, err := nrConfig.RemoteWrite.Build(nrConfig.DataSourceName)
+	remoteWrite, err := nrConfig.RemoteWrite.Build()
 	if err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
@@ -69,7 +69,7 @@ func expand(config *NrConfig) {
 	dataSourceName := os.Getenv(DataSourceNameEnvKey)
 
 	if dataSourceName != "" {
-		config.DataSourceName = dataSourceName
+		config.RemoteWrite.DataSourceName = dataSourceName
 	}
 
 	if dataSourceName != "" && config.Sharding.TotalShardsCount > 1 {

--- a/internal/configurator/builder_test.go
+++ b/internal/configurator/builder_test.go
@@ -68,15 +68,15 @@ func TestDataSourceName(t *testing.T) { //nolint: tparallel
 	t.Setenv(configurator.DataSourceNameEnvKey, "")
 
 	configWithDataSourceName := configurator.NrConfig{
-		DataSourceName: "test",
 		RemoteWrite: remotewrite.Config{
-			LicenseKey: "fake",
+			DataSourceName: "test",
+			LicenseKey:     "fake",
 		},
 	}
 
 	//nolint: paralleltest // need clean env variables.
 	t.Run("IsSetFromConfig", func(t *testing.T) {
-		configWithDataSourceName.DataSourceName = "prom-instance-name"
+		configWithDataSourceName.RemoteWrite.DataSourceName = "prom-instance-name"
 		promConf, err := configurator.BuildPromConfig(&configWithDataSourceName)
 		require.NoError(t, err)
 

--- a/internal/configurator/nr_config.go
+++ b/internal/configurator/nr_config.go
@@ -18,11 +18,6 @@ type RawPromConfig any
 type NrConfig struct {
 	// Common holds configuration for all options common to all scrape methods.
 	Common promcfg.GlobalConfig `yaml:"common"`
-	// DataSourceName holds the source name which will be used as `prometheus_server` parameter in New Relic remote
-	// write endpoint. See:
-	// <https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration/>
-	// for details.
-	DataSourceName string `yaml:"data_source_name"`
 	// Sharding holds the configuration for the sharding.
 	Sharding sharding.Config `yaml:"sharding"`
 	// RemoteWrite holds the New Relic remote write configuration.

--- a/internal/configurator/nr_config_test.go
+++ b/internal/configurator/nr_config_test.go
@@ -48,11 +48,11 @@ func testNrConfigExpectation(t *testing.T) NrConfig {
 				"three": "four",
 			},
 		},
-		DataSourceName: "data-source",
 		RemoteWrite: remotewrite.Config{
-			LicenseKey: "nrLicenseKey",
-			Staging:    true,
-			ProxyURL:   "http://proxy.url.to.use:1234",
+			DataSourceName: "data-source",
+			LicenseKey:     "nrLicenseKey",
+			Staging:        true,
+			ProxyURL:       "http://proxy.url.to.use:1234",
 			TLSConfig: &promcfg.TLSConfig{
 				InsecureSkipVerify: &trueValue,
 				CAFile:             "/path/to/ca.crt",

--- a/internal/configurator/testdata/nr-config-test.yaml
+++ b/internal/configurator/testdata/nr-config-test.yaml
@@ -6,8 +6,8 @@ common:
   scrape_timeout: 1s
   query_log_file: none
 
-data_source_name: data-source
 newrelic_remote_write:
+  data_source_name: data-source
   license_key: nrLicenseKey
   staging: true
   extra_write_relabel_configs:

--- a/internal/configurator/testdata/remote-write-test.yaml
+++ b/internal/configurator/testdata/remote-write-test.yaml
@@ -1,5 +1,5 @@
-data_source_name: "data-source"
 newrelic_remote_write:
+  data_source_name: "data-source"
   license_key: nrLicenseKey
   staging: true
   extra_write_relabel_configs:

--- a/internal/remotewrite/config.go
+++ b/internal/remotewrite/config.go
@@ -11,8 +11,16 @@ import (
 
 // Config defines all the NewRelic's remote write endpoint fields.
 type Config struct {
-	LicenseKey               string                  `yaml:"license_key"`
-	Staging                  bool                    `yaml:"staging"`
+	// LicenseKey holds the New Relic ingest license key of the account where metrics will be sent.
+	LicenseKey string `yaml:"license_key"`
+	// Staging configures the remote write url to point to the New Relic staging endpoint.
+	Staging bool `yaml:"staging"`
+	// DataSourceName holds the source name which will be used as `prometheus_server` parameter in New Relic remote
+	// write endpoint. See:
+	// <https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration/>
+	// for details.
+	DataSourceName string `yaml:"data_source_name"`
+	// FedRAMP configures the remote write url to point to the New Relic FedRAMP endpoint.
 	FedRAMP                  FedRAMP                 `yaml:"fedramp"`
 	ProxyURL                 string                  `yaml:"proxy_url"`
 	TLSConfig                *promcfg.TLSConfig      `yaml:"tls_config"`
@@ -28,12 +36,12 @@ type FedRAMP struct {
 }
 
 // Build will create the Prometheus remote_write entry for NewRelic.
-func (c Config) Build(dataSourceName string) (promcfg.RemoteWrite, error) {
+func (c Config) Build() (promcfg.RemoteWrite, error) {
 	rwu := NewURL(
 		WithFedRAMP(c.FedRAMP.Enabled),
 		WithLicense(c.LicenseKey),
 		WithStaging(c.Staging),
-		WithDataSourceName(dataSourceName),
+		WithDataSourceName(c.DataSourceName),
 	)
 
 	url, err := rwu.Build()

--- a/internal/remotewrite/config_test.go
+++ b/internal/remotewrite/config_test.go
@@ -18,8 +18,7 @@ func TestBuildRemoteWritePromConfig(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
-		remoteConfig   remotewrite.Config
-		dataSourceName string
+		remoteConfig remotewrite.Config
 	}
 
 	trueValue := true
@@ -46,11 +45,11 @@ func TestBuildRemoteWritePromConfig(t *testing.T) {
 		{
 			Name: "Staging, eu and all fields set",
 			NrConfig: args{
-				dataSourceName: "source-of-metrics",
 				remoteConfig: remotewrite.Config{
-					LicenseKey: "eu-fake-staging",
-					Staging:    true,
-					ProxyURL:   "http://proxy.url",
+					DataSourceName: "source-of-metrics",
+					LicenseKey:     "eu-fake-staging",
+					Staging:        true,
+					ProxyURL:       "http://proxy.url",
 					TLSConfig: &promcfg.TLSConfig{
 						CAFile:             "ca-file",
 						CertFile:           "cert-file",
@@ -119,7 +118,8 @@ func TestBuildRemoteWritePromConfig(t *testing.T) {
 		c := tc
 		t.Run(c.Name, func(t *testing.T) {
 			t.Parallel()
-			prometheusConfig, _ := c.NrConfig.remoteConfig.Build(c.NrConfig.dataSourceName)
+			prometheusConfig, err := c.NrConfig.remoteConfig.Build()
+			assert.NoError(t, err)
 			assert.EqualValues(t, c.Expected, prometheusConfig)
 		})
 	}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -32,8 +32,8 @@ func Test_ServerReady(t *testing.T) {
 	asserter := newAsserter(ps)
 
 	nrConfigConfig := `
-data_source_name: "data-source"
 newrelic_remote_write:
+  data_source_name: "data-source"
   license_key: nrLicenseKey
 `
 
@@ -137,8 +137,8 @@ static_targets:
       scrape_interval: 1s
       targets:
         - "localhost:%s"
-data_source_name: "data-source"
 newrelic_remote_write:
+  data_source_name: "data-source"
   license_key: nrLicenseKey
   proxy_url: %s
   tls_config:


### PR DESCRIPTION
While documenting this config i found it was at the base level.

Since this config configures the `prometheus_server` query parameter in the New Relic Remote write is a better place to put it there. 