### PR TITLE
bump configurator image (NR-54665) 

### DIFF
--- a/charts/newrelic-prometheus-agent/CHANGELOG.md
+++ b/charts/newrelic-prometheus-agent/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.0.5] - 2022-10-06
+### Changed
+- `newrelic-prometheus-configurator` image bumped `0.0.1` -> `0.0.2`.
+
 ## [0.0.4] - 2022-09-30
 ### Changed
 - Rename chart `newrelic-prometheus` -> `newrelic-prometheus-agent`.

--- a/charts/newrelic-prometheus-agent/Chart.yaml
+++ b/charts/newrelic-prometheus-agent/Chart.yaml
@@ -4,13 +4,13 @@ description: A Helm chart to deploy Prometheus with New Relic Prometheus Configu
 
 type: application
 
-version: 0.0.4
+version: 0.0.5
 
 # Prometheus Server Version
 appVersion: "v2.37.1"
 annotations:
 # TODO replace with the first configurator release
-  configuratorVersion: "0.0.1"
+  configuratorVersion: "0.0.2"
 
 dependencies:
   - name: common-library

--- a/charts/newrelic-prometheus-agent/ci/test-values.yaml
+++ b/charts/newrelic-prometheus-agent/ci/test-values.yaml
@@ -1,2 +1,6 @@
 licenseKey: fakeLicenseKey
 cluster: test-cluster-name
+images:
+  configurator:
+    repository: ct/prometheus-configurator
+    tag: ct


### PR DESCRIPTION
- use the correct generated image for ct
- bump configurator image to 0.0.2