### PR TITLE
[NR-55782] Release chart with release toolkit

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,0 +1,1 @@
+release-notes-file: release-notes.md

--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -5,3 +5,5 @@ target-branch: main
 
 chart-repos:
   - newrelic=https://helm-charts.newrelic.com
+
+check-version-increment: false

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -79,10 +79,9 @@ jobs:
       - name: Test install charts
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --namespace ct --config .github/ct.yaml --debug
-      # TODO: enable upgrade check once chart and values are considered stable
-      #- name: Test upgrade charts
-      #  if: steps.list-changed.outputs.changed == 'true'
-      #  run: ct install --namespace ct --config .github/ct.yaml --debug --upgrade
+      - name: Test upgrade charts
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --namespace ct --config .github/ct.yaml --debug --upgrade
 
   e2e-test:
     name: E2e Tests 

--- a/.github/workflows/releaseChart.yaml
+++ b/.github/workflows/releaseChart.yaml
@@ -37,7 +37,12 @@ jobs:
       version: ${{ steps.version.outputs.next-version }}
       image-tag: ${{ steps.image-tag.outputs.tag }}
     steps:
-      #TODO Add a check to be sure we are running over main
+      - name: Check is triggered for main branch
+        run: |
+          if [ ${{ env.GITHUB_REF_NAME }} != "main" ] || [ ${{ env.GITHUB_REF_TYPE }} != "branch" ];then
+            echo This workflow should only be triggered for the 'main' branch
+            exit 1
+          fi
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -69,7 +74,7 @@ jobs:
           markdown: ${{ env.CHART_DIRECTORY }}/CHANGELOG.md
       - name: Commit updated changelog
         run: |
-          yq e -i '.version="${{ steps.version.outputs.next-version }}"' charts/newrelic-prometheus-agent/Chart.yaml
+          yq e -i '.version="${{ steps.version.outputs.next-version }}"' ${{ env.CHART_DIRECTORY }}/Chart.yaml
           git add ${{ env.CHART_DIRECTORY }}/CHANGELOG.md
           git add ${{ env.CHART_DIRECTORY }}/Chart.yaml
           git commit -m "Update changelog and Chart.yaml with ${{ steps.version.outputs.next-version }}" changes

--- a/.github/workflows/releaseChart.yaml
+++ b/.github/workflows/releaseChart.yaml
@@ -52,8 +52,7 @@ jobs:
       - uses: newrelic/release-toolkit/link-dependencies@v1
         with:
           dictionary: .github/rt-dictionary.yaml
-      # TODO fix tag once it is merged
-      - uses: newrelic/release-toolkit/next-version@feat/prefixOutputAction
+      - uses: newrelic/release-toolkit/next-version@v1
         id: version
         with:
           tag-prefix: ${{  env.CHART_TAG_PREFIX }}

--- a/.github/workflows/releaseChart.yaml
+++ b/.github/workflows/releaseChart.yaml
@@ -1,8 +1,15 @@
 name: Release newrelic prometheus configurator chart
+# This workflow manually triggers the automated process of release based on the changelog.
+# Is recommended to run `make release-changelog` before to see an example of what is going to be generated.
+
+# IMPORTANT No matter the branch selected when triggered, the workflow will always execute on 'main' branch.
+
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+
+env:
+  CHART_DIRECTORY: 'charts/newrelic-prometheus-agent'
+  CHART_TAG_PREFIX: 'newrelic-prometheus-agent-'
 
 jobs:
   # Sometimes chart-releaser might fetch an outdated index.yaml from gh-pages, causing a WAW hazard on the repo
@@ -21,22 +28,60 @@ jobs:
           REMOTE="$(md5sum < index.yaml.remote)"
           echo "$LOCAL" = "$REMOTE"
           test "$LOCAL" = "$REMOTE"
+
   chart-release:
+    name: Create chart release
     runs-on: ubuntu-latest
-    needs: [ validate-gh-pages-index ]
+    outputs:
+      version: ${{ steps.version.outputs.next-version }}
+      image-tag: ${{ steps.image-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
+          ref: main
+      - name: Add newrelic repository
+        run: helm repo add newrelic https://helm-charts.newrelic.com
+      - uses: newrelic/release-toolkit/validate-markdown@v1
+      - uses: newrelic/release-toolkit/generate-yaml@v1
+        with:
+          included-dirs: ${{ env.CHART_DIRECTORY }}
+          markdown: ${{ env.CHART_DIRECTORY }}/CHANGELOG.md
+          tag-prefix: ${{  env.CHART_TAG_PREFIX }}
+      - uses: newrelic/release-toolkit/is-held@v1
+      - uses: newrelic/release-toolkit/link-dependencies@v1
+        with:
+          dictionary: .github/rt-dictionary.yaml
+      # TODO fix tag once it is merged
+      - uses: newrelic/release-toolkit/next-version@feat/prefixOutputAction
+        id: version
+        with:
+          tag-prefix: ${{  env.CHART_TAG_PREFIX }}
+          output-prefix: ""
+      - name: Set version in chart
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq e -i '.version="${{ steps.version.outputs.next-version }}"' charts/newrelic-prometheus-agent/Chart.yaml
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Add newrelic repository
-        run: helm repo add newrelic https://helm-charts.newrelic.com
-
+      - uses: newrelic/release-toolkit/update-markdown@v1
+        with:
+          version: ${{ steps.version.outputs.next-version }}
+          markdown: ${{ env.CHART_DIRECTORY }}/CHANGELOG.md
+      - name: Commit updated changelog
+        run: |
+          git add ${{ env.CHART_DIRECTORY }}/CHANGELOG.md
+          git add ${{ env.CHART_DIRECTORY }}/Chart.yaml
+          git commit -m "Update changelog and Chart.yaml with ${{ steps.version.outputs.next-version }}" changes
+          git push origin main
+      - uses: newrelic/release-toolkit/render@v1
+        with:
+          markdown: ${{ env.CHART_DIRECTORY }}/release-notes.md
       - name: Release workload charts
         uses: helm/chart-releaser-action@v1
+        with:
+          config: .github/cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/releaseChart.yaml
+++ b/.github/workflows/releaseChart.yaml
@@ -1,11 +1,11 @@
 name: Release newrelic prometheus configurator chart
 # This workflow manually triggers the automated process of release based on the changelog.
-# Is recommended to run `make release-changelog` before to see an example of what is going to be generated.
-
-# IMPORTANT No matter the branch selected when triggered, the workflow will always execute on 'main' branch.
+# Is recommended to run `make release-changelog-chart` before to see an example of what is going to be generated.
 
 on:
   workflow_dispatch:
+
+concurrency: helm-charts
 
 env:
   CHART_DIRECTORY: 'charts/newrelic-prometheus-agent'
@@ -32,10 +32,12 @@ jobs:
   chart-release:
     name: Create chart release
     runs-on: ubuntu-latest
+    needs: [ validate-gh-pages-index ]
     outputs:
       version: ${{ steps.version.outputs.next-version }}
       image-tag: ${{ steps.image-tag.outputs.tag }}
     steps:
+      #TODO Add a check to be sure we are running over main
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -57,10 +59,6 @@ jobs:
         with:
           tag-prefix: ${{  env.CHART_TAG_PREFIX }}
           output-prefix: ""
-      - name: Set version in chart
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq e -i '.version="${{ steps.version.outputs.next-version }}"' charts/newrelic-prometheus-agent/Chart.yaml
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
@@ -71,6 +69,7 @@ jobs:
           markdown: ${{ env.CHART_DIRECTORY }}/CHANGELOG.md
       - name: Commit updated changelog
         run: |
+          yq e -i '.version="${{ steps.version.outputs.next-version }}"' charts/newrelic-prometheus-agent/Chart.yaml
           git add ${{ env.CHART_DIRECTORY }}/CHANGELOG.md
           git add ${{ env.CHART_DIRECTORY }}/Chart.yaml
           git commit -m "Update changelog and Chart.yaml with ${{ steps.version.outputs.next-version }}" changes

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 CHANGELOG.md.bak
 CHANGELOG.partial.md
 changelog.yaml
+charts/newrelic-prometheus-agent/release-notes.md

--- a/Makefile
+++ b/Makefile
@@ -128,3 +128,26 @@ _release-changes:
 	@$(RT_BIN) validate-markdown
 	@$(RT_BIN) generate-yaml --excluded-dirs "charts,.github" --tag-prefix "v"
 	@$(RT_BIN) link-dependencies
+
+
+CHART_DIRECTORY="charts/newrelic-prometheus-agent"
+MARKDOWN_FILE=${CHART_DIRECTORY}/CHANGELOG.md
+CHART_PREFIX=newrelic-prometheus-agent-
+
+.PHONY: release-notes-chart
+release-notes-chart: _release-changes-chart
+	@$(RT_BIN) render-changelog --markdown ${CHART_DIRECTORY}/release-notes.md
+	@echo "RELEASE NOTES:\n"
+	@cat ${CHART_DIRECTORY}/release-notes.md
+
+### Upgrades the CHANGELOG.md as if a Release is being triggered.
+.PHONY: release-changelog-chart
+release-changelog-chart: _release-changes-chart
+	@$(RT_BIN) update-markdown --markdown ${MARKDOWN_FILE} --version $$($(RT_BIN) next-version --tag-prefix ${CHART_PREFIX})
+	@git --no-pager diff CHANGELOG.md
+
+### Prints out the Release Notes as if a Release is being triggered.
+.PHONY: _release-changes-chart
+_release-changes-chart:
+	$(RT_BIN) validate-markdown --markdown ${MARKDOWN_FILE}
+	$(RT_BIN) generate-yaml --markdown ${MARKDOWN_FILE} --included-dirs ${CHART_DIRECTORY}  --tag-prefix ${CHART_PREFIX}

--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ Release notes and new changelog can be previously checked by running the `make r
 
 **Manual release of images**:
 Is possible to manually trigger the build and push of a configurator image from any branch by executing the Actions->manualRelease->Run Workflow.
+#### newrelic-prometheus-agent Chart 
+
+The chart is released thanks to `helm/chart-releaser-action`, the package is hosted in Github releases and the index in Github pages.
+
+The release process uses the release toolkit in order to automatically compute the version, changelog and release notes from the `## Unreleased` section for the chart [Changelog.md](/charts/newrelic-prometheus-agent'/CHANGELOG.md) and dependency bots commits.
+
+> Therefore, the chart version should not be changed manually in the Chart.yaml, since it is automatically bumped.
+
+To trigger this release run [Release newrelic prometheus configurator chart](/.github/workflows/releaseChart.yaml) workflow. This workflow automatically calculates the version from the chart changelog and commits the new changelog and the version to the main branch.
+
+Release notes and new changelog can be previously checked by running the `make release-changelog-chart` and `make release-notes-chart` commands. Check [Release Toolkit](https://github.com/newrelic/release-toolkit#readme) for more details.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Is possible to manually trigger the build and push of a configurator image from 
 
 The chart is released thanks to `helm/chart-releaser-action`, the package is hosted in Github releases and the index in Github pages.
 
-The release process uses the release toolkit in order to automatically compute the version, changelog and release notes from the `## Unreleased` section for the chart [Changelog.md](/charts/newrelic-prometheus-agent'/CHANGELOG.md) and dependency bots commits.
+The release process uses the release toolkit in order to automatically compute the version, changelog and release notes from the `## Unreleased` section for the chart [Changelog.md](/charts/newrelic-prometheus-agent/CHANGELOG.md) and dependency bots commits.
 
 > Therefore, the chart version should not be changed manually in the Chart.yaml, since it is automatically bumped.
 


### PR DESCRIPTION
Merging this PR we will have a new process to release the chart:
 - changelog is updated automatically with release notes ([that should be part of the package](https://github.com/helm/chart-releaser/pull/217))
 - version is bumped automatically according to the changelog

As soon as well feel comfortable (even now if we want), we can automatize this easily by adding the `schedule` clause in the triggers.

The pipeline has been tested [here](https://github.com/paologallinaharbur/newrelic-prometheus-configurator/pull/1), few releases were created already in the fork from the changelog and dependabot.

My only concern with the approach is if it was easier so install `rt` and run the make, instead of having the logic twice being unable to test the code locally