### PR TITLE
feat(version): use the release toolkit overwriting the version

### DIFF
--- a/.github/workflows/releaseChart.yaml
+++ b/.github/workflows/releaseChart.yaml
@@ -1,9 +1,14 @@
-name: Release newrelic prometheus configurator chart
+name: Configurator Chart Release
 # This workflow manually triggers the automated process of release based on the changelog.
 # Is recommended to run `make release-changelog-chart` before to see an example of what is going to be generated.
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version including "v" prefix eg: v0.0.1 (Optional)'
+        required: false
+        type: string
 
 concurrency: helm-charts
 
@@ -62,6 +67,9 @@ jobs:
           dictionary: .github/rt-dictionary.yaml
       - uses: newrelic/release-toolkit/next-version@v1
         id: version
+        env:
+          # if specified the version will be not computed
+          NEXT: "${{ inputs.version }}"
         with:
           tag-prefix: ${{  env.CHART_TAG_PREFIX }}
           output-prefix: ""

--- a/.github/workflows/releaseConfigurator.yaml
+++ b/.github/workflows/releaseConfigurator.yaml
@@ -7,6 +7,11 @@ name: Configurator Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version including "v" prefix eg: v0.0.1 (Optional)'
+        required: false
+        type: string
 
 jobs:
   release:
@@ -36,6 +41,9 @@ jobs:
           dictionary: .github/rt-dictionary.yaml
       - uses: newrelic/release-toolkit/next-version@v1
         id: version
+        env:
+          # if specified this version will be used instead
+          NEXT: "${{ inputs.version }}"
       - id: image-tag
         run: |
           echo tag=$(echo "${{ steps.version.outputs.next-version }}" | sed 's/^v//') >> $GITHUB_OUTPUT


### PR DESCRIPTION
```
$ NEXT= rt next-version
v0.2.1

$ NEXT=v0.0.1 rt next-version
v0.0.1
```

For the integration there is already the "ReleaseManual" action, however, that is not leveraging the release toolkit and breaks the flow

Signed-off-by: paologallinaharbur <paologallina1992@gmail.com>