### PR TITLE
fix(promVersion): the version check did not fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,11 @@ chart-unit-test:
 	helm dependency update ./charts/newrelic-prometheus-agent
 	helm unittest ./charts/newrelic-prometheus-agent -3
 
-PROMETHEUS_VERSION_CHART := $(shell grep "appVersion" charts/newrelic-prometheus-agent/Chart.yaml | grep -o -E "(\.\d+.\d+)")
-PROMETHEUS_VERSION_GO := $(shell grep "github.com/prometheus/prometheus" go.mod| grep -o -E "(\.\d+.\d+)")
+PROMETHEUS_VERSION_CHART := $(shell grep "appVersion" charts/newrelic-prometheus-agent/Chart.yaml | grep -o -E "(\.[0-9]+\.[0-9]+)")
+PROMETHEUS_VERSION_GO := $(shell grep "github.com/prometheus/prometheus" go.mod| grep -o -E "(\.[0-9]+\.[0-9]+)")
 .PHONY: check-prometheus-version
 check-prometheus-version:
+	@echo PROMETHEUS_VERSION_CHART=$(PROMETHEUS_VERSION_CHART), PROMETHEUS_VERSION_GO=$(PROMETHEUS_VERSION_GO)
 ifneq ($(PROMETHEUS_VERSION_CHART), $(PROMETHEUS_VERSION_GO))
 	@echo "Prometheus server version defined in chart does not match with the one in Go dependency"
 	exit 1

--- a/charts/newrelic-prometheus-agent/CHANGELOG.md
+++ b/charts/newrelic-prometheus-agent/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### bugfix 
+- updated appVersion of `quay.io/prometheus/prometheus` from v2.37.1 to v2.37.2
+
 ## v0.2.1 - 2022-11-03
 
 ### 🐞 Bug fixes

--- a/charts/newrelic-prometheus-agent/Chart.yaml
+++ b/charts/newrelic-prometheus-agent/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to deploy Prometheus with New Relic Prometheus Configu
 type: application
 version: 0.2.1
 # Prometheus Server Version
-appVersion: "v2.37.1"
+appVersion: "v2.37.2"
 annotations:
   configuratorVersion: "0.2.0"
 dependencies:


### PR DESCRIPTION
The \d exists in less instances than [[:digit:]] (available in grep -P but not in POSIX).

