### PR TITLE
NR-70225: Send collector_version to the RW endpoint

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -142,6 +142,7 @@ jobs:
         with:
           minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ env.LATEST_K8S_VERSION }}
+          driver: docker
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
         run: make integration-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### enhancements
+- Send collector_version query param to the Remote Write endpoint.
+
 ## v1.0.0 - 2022-11-29
 
 ### First stable release

--- a/internal/configurator/builder.go
+++ b/internal/configurator/builder.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	ChartVersionEnvKey   = "NR_PROM_CHART_VERSION"
 	DataSourceNameEnvKey = "NR_PROM_DATA_SOURCE_NAME"
 	LicenseKeyEnvKey     = "NR_PROM_LICENSE_KEY"
 )
@@ -64,8 +65,12 @@ func expand(config *NrConfig) {
 		config.RemoteWrite.LicenseKey = licenseKey
 	}
 
-	dataSourceName := os.Getenv(DataSourceNameEnvKey)
+	chartVersion := os.Getenv(ChartVersionEnvKey)
+	if chartVersion != "" {
+		config.RemoteWrite.ChartVersion = chartVersion
+	}
 
+	dataSourceName := os.Getenv(DataSourceNameEnvKey)
 	if dataSourceName != "" {
 		config.RemoteWrite.DataSourceName = dataSourceName
 	}

--- a/internal/configurator/builder_test.go
+++ b/internal/configurator/builder_test.go
@@ -201,6 +201,43 @@ func TestShardingIndex(t *testing.T) { //nolint: paralleltest
 	}
 }
 
+func TestChartVersion(t *testing.T) { //nolint: paralleltest
+	t.Setenv(configurator.LicenseKeyEnvKey, "fake")
+
+	testCases := []struct {
+		name     string
+		expected string
+		setEnv   func()
+	}{
+		{
+			name:     "IsSetFromEnvVar",
+			expected: "1.0.1",
+			setEnv: func() {
+				t.Setenv(configurator.ChartVersionEnvKey, "1.0.1")
+			},
+		},
+		{
+			name:     "IsEmpty",
+			expected: "",
+			setEnv: func() {
+				t.Setenv(configurator.ChartVersionEnvKey, "")
+			},
+		},
+	}
+
+	for _, c := range testCases { //nolint: paralleltest
+		t.Run(c.name, func(t *testing.T) {
+			c.setEnv()
+			config := configurator.NrConfig{}
+
+			_, err := configurator.BuildPromConfig(&config)
+			require.NoError(t, err)
+
+			require.Equal(t, c.expected, config.RemoteWrite.ChartVersion)
+		})
+	}
+}
+
 func assertYamlPromConfigsAreEqual(t *testing.T, y1, y2 []byte) {
 	t.Helper()
 

--- a/internal/remotewrite/config.go
+++ b/internal/remotewrite/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	LicenseKey string `yaml:"license_key"`
 	// Staging configures the remote write url to point to the New Relic staging endpoint.
 	Staging bool `yaml:"staging"`
+	// ChartVersion holds the Chart version of the prometheus-configurator.
+	ChartVersion string `yaml:"-"`
 	// DataSourceName holds the source name which will be used as `prometheus_server` parameter in New Relic remote
 	// write endpoint. See:
 	// <https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration/>
@@ -46,6 +48,7 @@ func (c Config) Build() (promcfg.RemoteWrite, error) {
 		WithStaging(c.Staging),
 		WithDataSourceName(c.DataSourceName),
 		WithCollectorName(collectorName),
+		WithCollectorVersion(c.ChartVersion),
 	)
 
 	url, err := rwu.Build()

--- a/internal/remotewrite/remote_write_url.go
+++ b/internal/remotewrite/remote_write_url.go
@@ -22,6 +22,9 @@ const (
 	// to collector.name to comply with NR standards.
 	collectorNameQueryParam = "collector_name"
 	collectorName           = "prometheus-agent"
+	// collectorVersionQueryParam is a NR version of the component collecting the data. This is added as query parameter of the PRW and converted
+	// to collector.version to comply with NR standards.
+	collectorVersionQueryParam = "collector_version"
 )
 
 var (
@@ -87,6 +90,16 @@ func WithCollectorName(collectorName string) URLOption {
 		}
 
 		u.Values.Add(collectorNameQueryParam, collectorName)
+	}
+}
+
+func WithCollectorVersion(collectorVersion string) URLOption {
+	return func(u *URL) {
+		if collectorVersion == "" {
+			return
+		}
+
+		u.Values.Add(collectorVersionQueryParam, collectorVersion)
 	}
 }
 

--- a/internal/remotewrite/remote_write_url_test.go
+++ b/internal/remotewrite/remote_write_url_test.go
@@ -11,13 +11,14 @@ func TestRemoteWriteURL(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		Name           string
-		Staging        bool
-		FedRAMP        bool
-		LicenseKey     string
-		Expected       string
-		DataSourceName string
-		CollectorName  string
+		Name             string
+		Staging          bool
+		FedRAMP          bool
+		LicenseKey       string
+		Expected         string
+		DataSourceName   string
+		CollectorName    string
+		CollectorVersion string
 	}{
 		{
 			Name:       "staging non-eu",
@@ -70,6 +71,14 @@ func TestRemoteWriteURL(t *testing.T) {
 			CollectorName: "foo",
 			Expected:      "https://metric-api.newrelic.com/prometheus/v1/write?collector_name=foo",
 		},
+		{
+			Name:             "collectorVersion",
+			Staging:          false,
+			FedRAMP:          false,
+			LicenseKey:       "non-eu-license-key",
+			CollectorVersion: "1.0.0",
+			Expected:         "https://metric-api.newrelic.com/prometheus/v1/write?collector_version=1.0.0",
+		},
 	}
 
 	for _, testCase := range cases {
@@ -82,6 +91,7 @@ func TestRemoteWriteURL(t *testing.T) {
 				remotewrite.WithStaging(c.Staging),
 				remotewrite.WithDataSourceName(c.DataSourceName),
 				remotewrite.WithCollectorName(c.CollectorName),
+				remotewrite.WithCollectorVersion(c.CollectorVersion),
 			)
 			result, err := rwu.Build()
 			if assert.NoError(t, err) {


### PR DESCRIPTION
This PR sends the Chart version as a `collector_version` query param in the request to the Remote Write Endpoint.

I will add the `NR_PROM_CHART_VERSION` env var in the statefulset init container in a following PR where I'll be releasing the Chart with the new binary of the configurator.