### PR TITLE
NR-70225: set NR_PROM_CHART_VERSION env var in the statefulset init container

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -68,6 +68,8 @@ jobs:
         with:
           minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ matrix.kubernetes-version }}
+          # default driver doesn't support 'eval $$(minikube docker-env)'.
+          driver: docker
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create image for chart testing
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/newrelic-prometheus-agent/CHANGELOG.md
+++ b/charts/newrelic-prometheus-agent/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### enhancements
+- Set `NR_PROM_CHART_VERSION` env var in the configurator statefulset init container.
+
 ## v1.0.1 - 2022-11-30
 
 ### 🐞 Bug fixes

--- a/charts/newrelic-prometheus-agent/CHANGELOG.md
+++ b/charts/newrelic-prometheus-agent/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### enhancements
+### enhancement
 - Set `NR_PROM_CHART_VERSION` env var in the configurator statefulset init container.
 
 ## v1.0.1 - 2022-11-30

--- a/charts/newrelic-prometheus-agent/Chart.yaml
+++ b/charts/newrelic-prometheus-agent/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.0.1
 # Prometheus Server Version
 appVersion: "v2.37.5"
 annotations:
-  configuratorVersion: "1.0.0"
+  configuratorVersion: "1.1.0"
 dependencies:
   - name: common-library
     version: 1.1.0

--- a/charts/newrelic-prometheus-agent/Chart.yaml
+++ b/charts/newrelic-prometheus-agent/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.0.1
 # Prometheus Server Version
 appVersion: "v2.37.5"
 annotations:
-  configuratorVersion: "1.1.0"
+  configuratorVersion: "1.2.0"
 dependencies:
   - name: common-library
     version: 1.1.0

--- a/charts/newrelic-prometheus-agent/templates/statefulset.yaml
+++ b/charts/newrelic-prometheus-agent/templates/statefulset.yaml
@@ -71,6 +71,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "newrelic.common.license.secretName" . }}
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
+            - name: NR_PROM_CHART_VERSION
+              value: {{ .Chart.Version }}
 
       containers:
         - name: prometheus


### PR DESCRIPTION
This PR adds the`NR_PROM_CHART_VERSION` env var in the configurator statefulset Chart for to make it available to the configurator to send it to the RW endpoint.

I attach below a screenshot with the `Collector.Version` sent.

<img width="1927" alt="Screenshot 2023-01-26 at 11 57 43" src="https://user-images.githubusercontent.com/8235696/214819638-d4a1bc2e-44ef-459d-93b9-f5fbc9fc3247.png">
