### PR TITLE
Kubernetes bundle chart values

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -2,6 +2,20 @@
 
 The yaml files in this example folder can be used to test out New Relic's Prometheus-based Kubernetes monitoring quickstart.
 
+## If you are using the newrelic-bundle chart:
+
+If you're installing `newrelic-prometheus-configurator` as part of the Kubernetes integration package with the [newrelic-bundle](https://github.com/newrelic/helm-charts/tree/master/charts/nri-bundle) chart, use the values from [newrelic-bundle-values.yaml](newrelic-bundle-values.yaml) to configure the chart bundle. For example, to upgrade an existing installation with just the required values:
+
+```
+curl -O https://raw.githubusercontent.com/newrelic/newrelic-prometheus-configurator/main/examples/kubernetes/newrelic-bundle-values.yaml
+helm upgrade --reuse-values newrelic-bundle newrelic/nri-bundle -n newrelic -f newrelic-bundle-values.yaml
+```
+
+To add these values to a new installation, you can include them in your complete `values.yaml` file for the `newrelic-bundle` Helm chart. Or, if you're using the Helm command from the guided install wizard, you can add `-f newrelic-bundle-values.yaml` to the command to include those chart values with the new installation.
+
+
+## If you are using the newrelic-prometheus-configurator chart only:
+
 1. Deploy the following yamls. Note that if you already have KSM setup in your cluster, not all of these yamls will be necessary.
 
 ```

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -36,4 +36,6 @@ helm repo add newrelic-prometheus https://newrelic.github.io/newrelic-prometheus
 helm upgrade --install newrelic newrelic-prometheus/newrelic-prometheus-agent -f configurator-values.yaml
 ```
 
-4. Install the [Kubernetes Prometheus Quickstart dashboard](https://newrelic.com/instant-observability/kubernetes-prometheus) and watch for data to appear.
+## Install the dashboard
+
+Once the above is complete, install the [Kubernetes Prometheus Quickstart dashboard](https://newrelic.com/instant-observability/kubernetes-prometheus) and watch for data to appear.

--- a/examples/kubernetes/newrelic-bundle-values.yaml
+++ b/examples/kubernetes/newrelic-bundle-values.yaml
@@ -1,0 +1,110 @@
+kube-state-metrics:
+  enabled: true
+  podAnnotations:
+    prometheus.io/scrape: "true"
+newrelic-prometheus-agent:
+  enabled: true
+  config:
+    kubernetes:
+      integrations_filter:
+        source_labels: ["app.kubernetes.io/name", "app.newrelic.io/name"]
+        app_values: ["redis", "traefik", "calico", "nginx", "coredns", "etcd", "cockroachdb"]
+    static_targets:
+      jobs:
+  # New Relic: Scrape Configs
+
+  # Job to pull metrics from KSM
+      - job_name: kube-state-metrics
+        targets:
+          - 'kube-state-metrics.kube-system.svc.cluster.local:8080'
+        tls_config:
+          insecure_skip_verify: true
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  #      extra_metric_relabel_config:
+  #        - source_labels: [__name__]
+  #          regex: kube_node_status_capacity
+  #          action: keep
+
+  # Job to pull metrics from kubelet
+      - job_name: kubelet
+        kubernetes_sd_configs:
+          - role: node
+        targets:
+          - 'kubelet.kube-system.svc.cluster.local:10255'
+        scheme: https
+        tls_config:
+          insecure_skip_verify: true
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        authorization:
+          credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+  # Job to pull from apiserver
+      - job_name: "apiservers"
+        kubernetes_sd_configs:
+          - role: endpoints
+        # Default to scraping over https. If required, just disable this or change to
+        # `http`.
+        scheme: https
+        tls_config:
+          insecure_skip_verify: true
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          # If your node certificates are self-signed or use a different CA to the
+          # master CA, then disable certificate verification below. Note that
+          # certificate verification is an integral part of a secure infrastructure
+          # so this should only be disabled in a controlled environment. You can
+          # disable certificate verification by uncommenting the line below.
+          #
+          # insecure_skip_verify: true
+        authorization:
+          credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        # Keep only the default/kubernetes service endpoints for the https port. This
+        # will add targets for each API server which Kubernetes adds an endpoint to
+        # the default/kubernetes service.
+        relabel_configs:
+          - source_labels:
+              [
+                __meta_kubernetes_namespace,
+                __meta_kubernetes_service_name,
+                __meta_kubernetes_endpoint_port_name,
+              ]
+            action: keep
+            regex: default;kubernetes;https
+
+  # Job to pull metrics from cadvisor
+      - job_name: "cadvisor"
+
+        # Default to scraping over https. If required, just disable this or change to
+        # `http`.
+        scheme: https
+
+        # Starting Kubernetes 1.7.3 the cAdvisor metrics are under /metrics/cadvisor.
+        # Kubernetes CIS Benchmark recommends against enabling the insecure HTTP
+        # servers of Kubernetes, therefore the cAdvisor metrics on the secure handler
+        # are used.
+        metrics_path: /metrics/cadvisor
+
+        # This TLS & authorization config is used to connect to the actual scrape
+        # endpoints for cluster components. This is separate to discovery auth
+        # configuration because discovery & scraping are two separate concerns in
+        # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+        # the cluster. Otherwise, more config options have to be provided within the
+        # <kubernetes_sd_config>.
+        tls_config:
+          insecure_skip_verify: true
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+          # If your node certificates are self-signed or use a different CA to the
+          # master CA, then disable certificate verification below. Note that
+          # certificate verification is an integral part of a secure infrastructure
+          # so this should only be disabled in a controlled environment. You can
+          # disable certificate verification by uncommenting the line below.
+          #
+          # insecure_skip_verify: true
+        authorization:
+          credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)

--- a/examples/kubernetes/newrelic-bundle-values.yaml
+++ b/examples/kubernetes/newrelic-bundle-values.yaml
@@ -11,100 +11,100 @@ newrelic-prometheus-agent:
         app_values: ["redis", "traefik", "calico", "nginx", "coredns", "etcd", "cockroachdb"]
     static_targets:
       jobs:
-  # New Relic: Scrape Configs
+        # New Relic: Scrape Configs
 
-  # Job to pull metrics from KSM
-      - job_name: kube-state-metrics
-        targets:
-          - 'kube-state-metrics.kube-system.svc.cluster.local:8080'
-        tls_config:
-          insecure_skip_verify: true
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  #      extra_metric_relabel_config:
-  #        - source_labels: [__name__]
-  #          regex: kube_node_status_capacity
-  #          action: keep
+        # Job to pull metrics from KSM
+        - job_name: kube-state-metrics
+          targets:
+            - 'kube-state-metrics.kube-system.svc.cluster.local:8080'
+          tls_config:
+            insecure_skip_verify: true
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            #      extra_metric_relabel_config:
+            #        - source_labels: [__name__]
+            #          regex: kube_node_status_capacity
+            #          action: keep
 
-  # Job to pull metrics from kubelet
-      - job_name: kubelet
-        kubernetes_sd_configs:
-          - role: node
-        targets:
-          - 'kubelet.kube-system.svc.cluster.local:10255'
-        scheme: https
-        tls_config:
-          insecure_skip_verify: true
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        authorization:
-          credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        # Job to pull metrics from kubelet
+        - job_name: kubelet
+          kubernetes_sd_configs:
+            - role: node
+          targets:
+            - 'kubelet.kube-system.svc.cluster.local:10255'
+          scheme: https
+          tls_config:
+            insecure_skip_verify: true
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          authorization:
+            credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
-  # Job to pull from apiserver
-      - job_name: "apiservers"
-        kubernetes_sd_configs:
-          - role: endpoints
-        # Default to scraping over https. If required, just disable this or change to
-        # `http`.
-        scheme: https
-        tls_config:
-          insecure_skip_verify: true
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          # If your node certificates are self-signed or use a different CA to the
-          # master CA, then disable certificate verification below. Note that
-          # certificate verification is an integral part of a secure infrastructure
-          # so this should only be disabled in a controlled environment. You can
-          # disable certificate verification by uncommenting the line below.
-          #
-          # insecure_skip_verify: true
-        authorization:
-          credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        # Job to pull from apiserver
+        - job_name: "apiservers"
+          kubernetes_sd_configs:
+            - role: endpoints
+          # Default to scraping over https. If required, just disable this or change to
+          # `http`.
+          scheme: https
+          tls_config:
+            insecure_skip_verify: true
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            # If your node certificates are self-signed or use a different CA to the
+            # master CA, then disable certificate verification below. Note that
+            # certificate verification is an integral part of a secure infrastructure
+            # so this should only be disabled in a controlled environment. You can
+            # disable certificate verification by uncommenting the line below.
+            #
+            # insecure_skip_verify: true
+          authorization:
+            credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
-        # Keep only the default/kubernetes service endpoints for the https port. This
-        # will add targets for each API server which Kubernetes adds an endpoint to
-        # the default/kubernetes service.
-        relabel_configs:
-          - source_labels:
-              [
-                __meta_kubernetes_namespace,
-                __meta_kubernetes_service_name,
-                __meta_kubernetes_endpoint_port_name,
-              ]
-            action: keep
-            regex: default;kubernetes;https
+          # Keep only the default/kubernetes service endpoints for the https port. This
+          # will add targets for each API server which Kubernetes adds an endpoint to
+          # the default/kubernetes service.
+          relabel_configs:
+            - source_labels:
+                [
+                  __meta_kubernetes_namespace,
+                  __meta_kubernetes_service_name,
+                  __meta_kubernetes_endpoint_port_name,
+                ]
+              action: keep
+              regex: default;kubernetes;https
 
-  # Job to pull metrics from cadvisor
-      - job_name: "cadvisor"
+        # Job to pull metrics from cadvisor
+        - job_name: "cadvisor"
 
-        # Default to scraping over https. If required, just disable this or change to
-        # `http`.
-        scheme: https
+          # Default to scraping over https. If required, just disable this or change to
+          # `http`.
+          scheme: https
 
-        # Starting Kubernetes 1.7.3 the cAdvisor metrics are under /metrics/cadvisor.
-        # Kubernetes CIS Benchmark recommends against enabling the insecure HTTP
-        # servers of Kubernetes, therefore the cAdvisor metrics on the secure handler
-        # are used.
-        metrics_path: /metrics/cadvisor
+          # Starting Kubernetes 1.7.3 the cAdvisor metrics are under /metrics/cadvisor.
+          # Kubernetes CIS Benchmark recommends against enabling the insecure HTTP
+          # servers of Kubernetes, therefore the cAdvisor metrics on the secure handler
+          # are used.
+          metrics_path: /metrics/cadvisor
 
-        # This TLS & authorization config is used to connect to the actual scrape
-        # endpoints for cluster components. This is separate to discovery auth
-        # configuration because discovery & scraping are two separate concerns in
-        # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-        # the cluster. Otherwise, more config options have to be provided within the
-        # <kubernetes_sd_config>.
-        tls_config:
-          insecure_skip_verify: true
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          # This TLS & authorization config is used to connect to the actual scrape
+          # endpoints for cluster components. This is separate to discovery auth
+          # configuration because discovery & scraping are two separate concerns in
+          # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+          # the cluster. Otherwise, more config options have to be provided within the
+          # <kubernetes_sd_config>.
+          tls_config:
+            insecure_skip_verify: true
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 
-          # If your node certificates are self-signed or use a different CA to the
-          # master CA, then disable certificate verification below. Note that
-          # certificate verification is an integral part of a secure infrastructure
-          # so this should only be disabled in a controlled environment. You can
-          # disable certificate verification by uncommenting the line below.
-          #
-          # insecure_skip_verify: true
-        authorization:
-          credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        kubernetes_sd_configs:
-          - role: node
-        relabel_configs:
-          - action: labelmap
-            regex: __meta_kubernetes_node_label_(.+)
+            # If your node certificates are self-signed or use a different CA to the
+            # master CA, then disable certificate verification below. Note that
+            # certificate verification is an integral part of a secure infrastructure
+            # so this should only be disabled in a controlled environment. You can
+            # disable certificate verification by uncommenting the line below.
+            #
+            # insecure_skip_verify: true
+          authorization:
+            credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)


### PR DESCRIPTION
Adds documentation and sample configuration for the use case where someone has the newrelic/nri-bundle chart and wants to configure the `newrelic-prometheus-configurator` subchart for the Kubelet dashboard.