### PR TITLE
feat: Add metric_relabel_config to assist with POMI migrations

### DIFF
--- a/charts/newrelic-prometheus-agent/values.yaml
+++ b/charts/newrelic-prometheus-agent/values.yaml
@@ -139,14 +139,13 @@ config:
   # -- (object) Newrelic remote-write configuration settings.
   # @default -- See `values.yaml`
   newrelic_remote_write:
-    # -- Includes additional [relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
-    # for the New Relic remote write.
-    # @default -- `[]`
-    # extra_write_relabel_configs:
-    #
+    # # -- Includes additional [relabel configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
+    # # for the New Relic remote write.
+    # # @default -- `[]`
+    # extra_write_relabel_configs: []
+
     #   # Enable the extra_write_relabel_configs below for backwards compatibility with legacy POMI labels.
-    #   # This helpful when migrating from POMI to ensure that Prometheus metrics will
-    #   # contain both labels (e.g. cluster_name and clusterName).
+    #   # This helpful when migrating from POMI to ensure that Prometheus metrics will contain both labels (e.g. cluster_name and clusterName).
     #   # For more migration info, please visit the [migration guide](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/migration-guide/).
     #   - source_labels: [namespace]
     #     action: replace

--- a/charts/newrelic-prometheus-agent/values.yaml
+++ b/charts/newrelic-prometheus-agent/values.yaml
@@ -143,6 +143,32 @@ config:
     # for the New Relic remote write.
     # @default -- `[]`
     # extra_write_relabel_configs:
+    #
+    #   # Enable the extra_write_relabel_configs below for backwards compatibility with legacy POMI labels.
+    #   # This helpful when migrating from POMI to ensure that Prometheus metrics will
+    #   # contain both labels (e.g. cluster_name and clusterName).
+    #   # For more migration info, please visit the [migration guide](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/migration-guide/).
+    #   - source_labels: [namespace]
+    #     action: replace
+    #     target_label: namespaceName
+    #   - source_labels: [node]
+    #     action: replace
+    #     target_label: nodeName
+    #   - source_labels: [pod]
+    #     action: replace
+    #     target_label: podName
+    #   - source_labels: [service]
+    #     action: replace
+    #     target_label: serviceName
+    #   - source_labels: [cluster_name]
+    #     action: replace
+    #     target_label: clusterName
+    #   - source_labels: [job]
+    #     action: replace
+    #     target_label: scrapedTargetKind
+    #   - source_labels: [instance]
+    #     action: replace
+    #     target_label: scrapedTargetInstance
 
     # -- Set up the proxy used to send metrics to New Relic.
     # @default -- `""`


### PR DESCRIPTION
Customers migrating from POMI may have dashboards and alerts built using the previous attribute names (e.g. clusterName, namespaceName, etc).  I've added a metric_relabel_config (commented out by default) that can be used to add these legacy attributes to Prometheus metrics for continuity.