### PR TITLE
fix(cicd): default branch check

### DIFF
--- a/.github/workflows/releaseChart.yaml
+++ b/.github/workflows/releaseChart.yaml
@@ -42,16 +42,16 @@ jobs:
       version: ${{ steps.version.outputs.next-version }}
       image-tag: ${{ steps.image-tag.outputs.tag }}
     steps:
-      - name: Check is triggered for main branch
+      - name: Check is triggered for default branch
         run: |
-          if [ ${{ env.GITHUB_REF_NAME }} != "main" ] || [ ${{ env.GITHUB_REF_TYPE }} != "branch" ];then
-            echo This workflow should only be triggered for the 'main' branch
+          if [ ${GITHUB_REF_NAME} != ${{ github.event.repository.default_branch }} ] || [ ${GITHUB_REF_TYPE} != "branch" ];then
+            echo This workflow should only be triggered for the '${{ github.event.repository.default_branch }}' branch
             exit 1
           fi
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.event.repository.default_branch }}
           token: "${{ secrets.COREINT_BOT_TOKEN }}"
       - name: Add newrelic repository
         run: helm repo add newrelic https://helm-charts.newrelic.com
@@ -87,7 +87,7 @@ jobs:
           git add ${{ env.CHART_DIRECTORY }}/CHANGELOG.md
           git add ${{ env.CHART_DIRECTORY }}/Chart.yaml
           git commit -m "Update changelog and Chart.yaml with ${{ steps.version.outputs.next-version }} changes"
-          git push origin main
+          git push origin ${{ github.event.repository.default_branch }}
       - uses: newrelic/release-toolkit/render@v1
         with:
           markdown: ${{ env.CHART_DIRECTORY }}/release-notes.md

--- a/.github/workflows/releaseConfigurator.yaml
+++ b/.github/workflows/releaseConfigurator.yaml
@@ -3,7 +3,7 @@ name: Configurator Release
 # This workflow manually triggers the automated process of release based on the changelog.
 # Is recommended to run `make release-changelog` before to see an example of what is going to be generated.
 
-# IMPORTANT No matter the branch selected when triggered, the workflow will always execute on 'main' branch.
+# IMPORTANT No matter the branch selected when triggered, the workflow will always execute on default branch.
 
 on:
   workflow_dispatch:
@@ -21,16 +21,16 @@ jobs:
       version: ${{ steps.version.outputs.next-version }}
       image-tag: ${{ steps.image-tag.outputs.tag }}
     steps:
-      - name: Check is triggered for main branch
+      - name: Check is triggered for default branch
         run: |
-          if [ ${{ env.GITHUB_REF_NAME }} != "main" ] || [ ${{ env.GITHUB_REF_TYPE }} != "branch" ];then
-            echo This workflow should only be triggered for the 'main' branch
+          if [ ${GITHUB_REF_NAME} != ${{ github.event.repository.default_branch }} ] || [ ${GITHUB_REF_TYPE} != "branch" ];then
+            echo This workflow should only be triggered for the '${{ github.event.repository.default_branch }}' branch
             exit 1
           fi
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.event.repository.default_branch }}
           token: "${{ secrets.COREINT_BOT_TOKEN }}"
       - uses: newrelic/release-toolkit/validate-markdown@v1
       - uses: newrelic/release-toolkit/generate-yaml@v1
@@ -58,7 +58,7 @@ jobs:
         run: |
           git add CHANGELOG.md
           git commit -m "Update changelog with changes from ${{ steps.version.outputs.next-version }}"
-          git push -u origin main
+          git push -u origin ${{ github.event.repository.default_branch }}
       - uses: newrelic/release-toolkit/render@v1
       - name: Create Release
         env:


### PR DESCRIPTION
There was an error in the pipeline:
```
${{ env.GITHUB_REF_NAME }} != "main"
```
is not working as expected since GITHUB_REF_NAME is a default environment variable and cannot be accessed by `env.` and it is available in the shell only.

That is why the error was:
```
Run if [  != "main" ] || [  != "branch" ];then
/home/runner/work/_temp/f1a9d61a-[7](https://github.com/newrelic/newrelic-prometheus-configurator/actions/runs/4017170116/jobs/6901172427#step:8:8)7d5-4ec3-[8](https://github.com/newrelic/newrelic-prometheus-configurator/actions/runs/4017170116/jobs/6901172427#step:8:9)a03-e49968586243.sh: line 1: [: !=: unary operator expected
/home/runner/work/_temp/f1a9d61a-77d5-4ec3-8a03-e49968586243.sh: line 1: [: !=: unary operator expected
```

Moreover, the pipeline makes generic the default branch check check 

Approach copied from: https://github.com/newrelic/nri-kafka/pull/213