### PR TITLE
Fix helm unittest

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -44,7 +44,7 @@ jobs:
 
           for chart in $(ct --config .github/ct.yaml list-changed); do
             if [ -d "$chart/tests/" ]; then
-              helm unittest -3 $chart
+              helm unittest $chart
             else
               echo "No unit tests found for $chart"
             fi
@@ -58,7 +58,7 @@ jobs:
         run: |
           go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
           make build-chart-docs
-          if [ ! -z "$(git status --porcelain)" ]; then 
+          if [ ! -z "$(git status --porcelain)" ]; then
             git diff
             exit 1
           fi
@@ -86,7 +86,7 @@ jobs:
         run: ct install --namespace ct --config .github/ct.yaml --debug --upgrade
 
   e2e-test:
-    name: E2e Tests 
+    name: E2e Tests
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
     runs-on: ubuntu-latest
     # If the environment is broken this job could timeout since the default timeout for tilt ci is 30m.
@@ -178,7 +178,7 @@ jobs:
       #   run: |
       #     go install go.elastic.co/go-licence-detector@v0.5.0
       #     make build-license-notice
-      #     if [ ! -z "$(git status --porcelain)" ]; then 
+      #     if [ ! -z "$(git status --porcelain)" ]; then
       #       git diff
       #       exit 1
       #     fi

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -113,7 +113,7 @@ jobs:
         if: ${{ env.SECRET_AVAILABLE != '' }}
         uses: newrelic/newrelic-integration-e2e-action@v1
         with:
-          retry_seconds: 60
+          retry_seconds: 90
           retry_attempts: 5
           agent_enabled: false
           spec_path: test/e2e/test-specs.yml

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Run helm unit tests
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          helm plugin install https://github.com/quintush/helm-unittest
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version=0.3.2
 
           for chart in $(ct --config .github/ct.yaml list-changed); do
             if [ -d "$chart/tests/" ]; then

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -90,7 +90,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
     runs-on: ubuntu-latest
     # If the environment is broken this job could timeout since the default timeout for tilt ci is 30m.
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - name: Setup Minikube

--- a/charts/newrelic-prometheus-agent/Chart.yaml
+++ b/charts/newrelic-prometheus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: newrelic-prometheus-agent
 description: A Helm chart to deploy Prometheus with New Relic Prometheus Configurator.
 type: application
-version: 1.1.1
+version: 1.1.2
 # Prometheus Server Version
 appVersion: "v2.37.5"
 annotations:

--- a/charts/newrelic-prometheus-agent/Chart.yaml
+++ b/charts/newrelic-prometheus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: newrelic-prometheus-agent
 description: A Helm chart to deploy Prometheus with New Relic Prometheus Configurator.
 type: application
-version: 1.1.2
+version: 1.1.1
 # Prometheus Server Version
 appVersion: "v2.37.5"
 annotations:

--- a/charts/newrelic-prometheus-agent/tests/configmap_test.yaml
+++ b/charts/newrelic-prometheus-agent/tests/configmap_test.yaml
@@ -8,7 +8,7 @@ tests:
       cluster: cluster-test
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -90,7 +90,7 @@ tests:
         static_targets:  # Set empty to make this test simple
     asserts:
       - matchRegex:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           pattern: "newrelic_remote_write:\n  staging: true"  # We do not want to test the whole YAML
 
   - it: fedramp is enabled
@@ -105,7 +105,7 @@ tests:
         static_targets:  # Set empty to make this test simple
     asserts:
       - matchRegex:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           pattern: "newrelic_remote_write:\n  fedramp:\n    enabled: true"  # We do not want to test the whole YAML
 
   - it: config including remote_write most possible sections
@@ -134,7 +134,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -191,7 +191,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -218,7 +218,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -238,7 +238,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -260,7 +260,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -288,7 +288,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -372,7 +372,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             static_targets:
@@ -482,7 +482,7 @@ tests:
         static_targets:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -536,7 +536,7 @@ tests:
         static_targets:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -557,7 +557,7 @@ tests:
         static_targets:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:

--- a/charts/newrelic-prometheus-agent/tests/configmap_test.yaml
+++ b/charts/newrelic-prometheus-agent/tests/configmap_test.yaml
@@ -8,7 +8,7 @@ tests:
       cluster: cluster-test
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -90,7 +90,7 @@ tests:
         static_targets:  # Set empty to make this test simple
     asserts:
       - matchRegex:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           pattern: "newrelic_remote_write:\n  staging: true"  # We do not want to test the whole YAML
 
   - it: fedramp is enabled
@@ -105,7 +105,7 @@ tests:
         static_targets:  # Set empty to make this test simple
     asserts:
       - matchRegex:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           pattern: "newrelic_remote_write:\n  fedramp:\n    enabled: true"  # We do not want to test the whole YAML
 
   - it: config including remote_write most possible sections
@@ -134,7 +134,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -191,7 +191,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -218,7 +218,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -238,7 +238,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -260,7 +260,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -288,7 +288,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -372,7 +372,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             static_targets:
@@ -482,7 +482,7 @@ tests:
         static_targets:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -536,7 +536,7 @@ tests:
         static_targets:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -557,7 +557,7 @@ tests:
         static_targets:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:

--- a/charts/newrelic-prometheus-agent/tests/configmap_test.yaml
+++ b/charts/newrelic-prometheus-agent/tests/configmap_test.yaml
@@ -208,6 +208,7 @@ tests:
 
   - it: cluster_name is set from global
     set:
+      licenseKey: license-key-test
       global:
        cluster: "test"
       metric_type_override:
@@ -227,6 +228,7 @@ tests:
               scrape_interval: 30s
   - it: cluster_name local value has precedence over global precedence
     set:
+      licenseKey: license-key-test
       global:
         cluster: "test"
       cluster: "test2"
@@ -247,6 +249,7 @@ tests:
               scrape_interval: 30s
   - it: cluster_name is not overwritten from customAttributes
     set:
+      licenseKey: license-key-test
       global:
         cluster: "test"
       cluster: "test2"
@@ -270,6 +273,7 @@ tests:
 
   - it: cluster_name has precedence over extra labels has precedence over customAttributes
     set:
+      licenseKey: license-key-test
       cluster: test
       customAttributes:
         attribute: "value"

--- a/charts/newrelic-prometheus-agent/tests/integration_filters_test.yaml
+++ b/charts/newrelic-prometheus-agent/tests/integration_filters_test.yaml
@@ -16,7 +16,7 @@ tests:
         static_targets:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -74,7 +74,7 @@ tests:
         static_targets:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:

--- a/charts/newrelic-prometheus-agent/tests/integration_filters_test.yaml
+++ b/charts/newrelic-prometheus-agent/tests/integration_filters_test.yaml
@@ -16,7 +16,7 @@ tests:
         static_targets:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:
@@ -74,7 +74,7 @@ tests:
         static_targets:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             common:

--- a/charts/newrelic-prometheus-agent/tests/lowdatamode_configmap_test.yaml
+++ b/charts/newrelic-prometheus-agent/tests/lowdatamode_configmap_test.yaml
@@ -15,7 +15,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -43,7 +43,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -72,7 +72,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -105,7 +105,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data["data.config.yaml"]
+          path: data["config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:

--- a/charts/newrelic-prometheus-agent/tests/lowdatamode_configmap_test.yaml
+++ b/charts/newrelic-prometheus-agent/tests/lowdatamode_configmap_test.yaml
@@ -15,7 +15,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -43,7 +43,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -72,7 +72,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:
@@ -105,7 +105,7 @@ tests:
         kubernetes:
     asserts:
       - equal:
-          path: data.config\.yaml
+          path: data["data.config.yaml"]
           value: |-
             # Configuration for newrelic-prometheus-configurator
             newrelic_remote_write:


### PR DESCRIPTION
Fixes https://github.com/newrelic/newrelic-prometheus-configurator/actions/runs/4866013780/jobs/8677044897?pr=213

Now that https://github.com/helm-unittest/helm-unittest/pull/114 has made Helm3 support the default, we no longer need to specify Helm3.

### Testing Plan
- Bump helm chart version so that the `Run helm unit tests` github workflow step runs
- Fix helm unit tests so that they pass
- Revert chart version bump
