### PR TITLE
Fix E2E tests

### DIFF
--- a/test/e2e/test-specs.yml
+++ b/test/e2e/test-specs.yml
@@ -43,5 +43,5 @@ scenarios:
         - query: "FROM Metric select metricName  where collector_type = 'integration-filters' and service = 'kube-dns'"
           error_expected: true
         # metric type relabelling, the metric name is wrong, but since the prefix matches timeseries_write_* we expect it as a counter
-        - query: "FROM Metric select metricName where collector_type = 'integration-filters' and metricName = 'timeseries_write_test' and getField(timeseries_write_test,'type') = 'count'"
+        - query: "FROM Metric select metricName where collector_type = 'integration-filters' and metricName = 'timeseries_write_test' and getField(timeseries_write_test,'type') = 'cumulativeCount'"
           error_expected: false #In this case we expect the metrics thanks to the newrelic.io/scrape=true


### PR DESCRIPTION
E2E tests are failing on [this NRQL query](https://github.com/newrelic/newrelic-prometheus-configurator/blob/main/test/e2e/test-specs.yml#L46).  
This NRQL query tests the [metric type relabeling](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration/#override-mapping) feature, using the metric relabel defaults defined [here](https://github.com/newrelic/newrelic-prometheus-configurator/blob/main/charts/newrelic-prometheus-agent/static/metrictyperelabeldefaults.yaml#L6).

It appears we recently started emitting `cumulativeCount` by default (instead of type `count`) as mentioned in this [TDP PR](https://source.datanerd.us/dimensional-metrics/otlp-metrics-consumer/pull/184):
<img width="1066" alt="Screenshot 2023-05-11 at 10 10 08 AM" src="https://github.com/newrelic/newrelic-prometheus-configurator/assets/66266496/db660586-7f17-4d2c-bda8-b561c46566ec">

Confirmation by TDP that this was an intentional change: 
https://newrelic.slack.com/archives/CH292BVUZ/p1683831499673729?thread_ts=1683831020.191729&cid=CH292BVUZ
