### PR TITLE
Fix golangci-lint

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -168,7 +168,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
-          args: --verbose
+          only-new-issues: true
       - name: Prometheus versions match
         run: make check-prometheus-version
 


### PR DESCRIPTION
Modifying push pr workflow to match workflow from [nri-kubernetes](https://github.com/newrelic/nri-kubernetes/blob/main/.github/workflows/push_pr.yaml#L124)