### PR TITLE
chore: Update CHANGELOG format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,22 @@ Before submitting an Issue, please search for similar ones in the
 
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
 2. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-3. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
+3. Add an entry as an unordered list to the CHANGELOG under the `Unreleased` section under an L3 header that specifies the type of your PR. If there is no L3 header for your type of PR already in the Unreleased section, add a new L3 header. Include your github handle and a link to your PR in the entry. Here's an example of how it should look:
+    ```md
+      ## Unreleased
+
+      ### bugfix
+      - Fix some bug in some file @yourGithubHandle [#123](linkToThisPR)
+    ```
+
+  - Here are the accepted L3 headers (case sensitive)
+    + `breaking`
+    + `security`
+    + `enhancement`
+    + `bugfix`
+    + `dependency`
+
+4. You may merge the Pull Request in once you have the sign-off of one other developers, or if you do not have permission to do that, you may request the other reviewer to merge it for you.
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
In order to use the release toolkit, we need to follow a certain changelog format: https://github.com/newrelic/release-toolkit/blob/main/generate-yaml/README.md

This PR only updates the PR docs because the changelog is already in the correct format: https://github.com/newrelic/newrelic-prometheus-configurator/blob/main/CHANGELOG.md