### PR TITLE
chore: Add CHANGELOG github workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,8 @@
     // Disable the creation of this issue that renovate updates with the pending issue we follow.
     ":disableDependencyDashboard"
   ],
+  // Label PRs with `dependencies`.
+  "labels": ["dependencies"],
   "enabledManagers": [
     // Needed to bump the conifgurator version.
     "regex",

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,37 @@
+# This action requires that any PR should touch at
+# least one CHANGELOG file.
+
+name: changelog
+
+on:
+  pull_request:
+
+jobs:
+  changelog-entry:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for CHANGELOG file changes
+        run: |
+          # Only the latest commit of the feature branch is available
+          # automatically. To diff with the base branch, we need to
+          # fetch that too (and we only need its latest commit).
+          git fetch origin ${{ github.base_ref }} --depth=1
+          if [[ $(git diff --name-only FETCH_HEAD | grep --ignore-case CHANGELOG) ]]
+          then
+            echo "The CHANGELOG file was modified. Looks good!"
+          else
+            echo "The CHANGELOG file was not modified."
+            echo "Please add a CHANGELOG entry to the appropriate header under \"Unreleased\", or add the \"Skip Changelog\" label if not required."
+            false
+          fi
+  lint-changelog:
+    runs-on: ubuntu-latest
+    needs: changelog-entry
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Check if CHANGELOG is valid
+        uses: newrelic/release-toolkit/validate-markdown@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ Before submitting an Issue, please search for similar ones in the
     + `bugfix`
     + `dependency`
 
+  - You can skip the changelog requirement by using the "Skip Changelog" label if your pull request is only updating files related to the CI/CD process or minor doc changes.
+
 4. You may merge the Pull Request in once you have the sign-off of one other developers, or if you do not have permission to do that, you may request the other reviewer to merge it for you.
 
 ## Contributor License Agreement


### PR DESCRIPTION
## Which problem is this PR solving?

Adding a changelog action that valids if a PR updates a changelog by using the newrelic/release-toolkit/validate-markdown@v1.

## Short description of the changes
- Added changelog
- Added dependencies label to renovatebot
- Update docs

## Type of change

Please delete options that are not relevant.

- [x] New feature / enhancement (non-breaking change which adds functionality)

## New Tests?
Please describe the new tests that were added (if applicable).

Not applicable for this pr

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [x] Documentation has been updated