### PR TITLE
Update Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+- Add resource configuration option for initContainers. I accidentally push a commit to the repo main branch directly https://github.com/newrelic/newrelic-prometheus-configurator/commit/cf752524b70fe4d351beb7da57a45d529b2aeece
+
 ## v1.5.0 - 2023-08-21
 
 ### ⛓️ Dependencies


### PR DESCRIPTION
## Which problem is this PR solving?

In the newrelic-prometheus-agent chart, customers cannot config the resource limits and request of the initContainer configurator.

I accidentally push a commit to the repo main branch directly https://github.com/newrelic/newrelic-prometheus-configurator/commit/cf752524b70fe4d351beb7da57a45d529b2aeece

## Short description of the changes
Enable customers to config the resource limits and request of the initContainer configurator.

## Type of change

- [*] Security fix

## New Tests?
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [*] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated