### PR TITLE
Update K8s Versions in E2E Tests

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   # NOTICE that apart from this, the versions in the chart linter matrix needs to be bumped too.
-  LATEST_K8S_VERSION: 'v1.27.5'
+  LATEST_K8S_VERSION: '1.25.13'
   MINIKUBE_VERSION: 'v1.30.1'
 
 jobs:

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   # NOTICE that apart from this, the versions in the chart linter matrix needs to be bumped too.
-  LATEST_K8S_VERSION: '1.25.13'
+  LATEST_K8S_VERSION: '1.27.5'
   MINIKUBE_VERSION: 'v1.30.1'
 
 jobs:

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   # NOTICE that apart from this, the versions in the chart linter matrix needs to be bumped too.
-  LATEST_K8S_VERSION: '1.27.5'
+  LATEST_K8S_VERSION: '1.25.13'
   MINIKUBE_VERSION: 'v1.30.1'
 
 jobs:

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -7,8 +7,8 @@ on:
 
 env:
   # NOTICE that apart from this, the versions in the chart linter matrix needs to be bumped too.
-  LATEST_K8S_VERSION: 'v1.24.4'
-  MINIKUBE_VERSION: 'v1.28.0'
+  LATEST_K8S_VERSION: 'v1.27.5'
+  MINIKUBE_VERSION: 'v1.30.1'
 
 jobs:
   chart-lint:
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        kubernetes-version: [ "v1.16.15", "v1.24.4" ]
+        kubernetes-version: [ "1.23.17", "1.24.17", "1.25.13", "1.26.8", "1.27.5" ]
     steps:
       - uses: azure/setup-helm@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 - Add resource configuration option for initContainers. I accidentally push a commit to the repo main branch directly https://github.com/newrelic/newrelic-prometheus-configurator/commit/cf752524b70fe4d351beb7da57a45d529b2aeece
 
+### Enhancement
+- Update K8s Versions in E2E Tests by @xqi-nr in [#265](https://github.com/newrelic/newrelic-prometheus-configurator/pull/265)
+
 ## v1.5.0 - 2023-08-21
 
 ### ⛓️ Dependencies


### PR DESCRIPTION
## Which problem is this PR solving?

The K8s versions in E2e Tests are old.

## Short description of the changes

Check the GitHub workflows that run for PR pushes and:
Remove any references to Kubernetes versions 1.22 or older
Add to tests Kubernetes versions: 1.23.17, 1.24.17, 1.25.13, 1.26.8, 1.27.5

`LATEST_K8S_VERSION: '1.25.13'` is the latest k8s version that does not break the [Run Tests](https://github.com/newrelic/newrelic-prometheus-configurator/blob/705dec67fd83b7d604f0421f8288d2d68aa117fc/.github/workflows/push_pr.yaml#L128)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## New Tests?


## Checklist:
- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [x] Tests have been updated