### PR TITLE
ci: Update minikube version

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -8,7 +8,7 @@ on:
 env:
   # NOTICE that apart from this, the versions in the chart linter matrix needs to be bumped too.
   LATEST_K8S_VERSION: 'v1.25.13'
-  MINIKUBE_VERSION: 'v1.30.1'
+  MINIKUBE_VERSION: 'v1.31.2'
 
 jobs:
   chart-lint:


### PR DESCRIPTION
## Which problem is this PR solving?

Updating minikube version so Helm chart linting works for Kubernetes v 1.27

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security fix
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## New Tests?
Please describe the new tests that were added (if applicable).

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated