### PR TITLE
fix: Workflow should not fail if Trivy detects vulnerability

### DIFF
--- a/.github/workflows/_push_image.yaml
+++ b/.github/workflows/_push_image.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           image-ref: '${{ env.DOCKER_IMAGE_NAME }}:ci-scan'
           format: 'table'
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
We now keep track of security vulnerabilities in the Security Tab. In addition, failing a PR does not solve the fact that we have to wait for third parties to fix a vulnerabilty, so blocking a PR does not speed up this dependency fix.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests