### PR TITLE
fix: Fix integration test

### DIFF
--- a/test/integration/integration_kubernetes_test.go
+++ b/test/integration/integration_kubernetes_test.go
@@ -406,13 +406,13 @@ kubernetes:
 		"__meta_kubernetes_pod_name":     runningPod.Name,
 		"__meta_kubernetes_service_name": svc.Name,
 	})
-	asserter.droppedTargetLabels(t, map[string]string{
-		"__meta_kubernetes_pod_name":     succeededPod.Name,
-		"__meta_kubernetes_service_name": svc.Name,
-	})
 
 	// Failed Pods are not added as endpoints of the service in K8s.
 	// This could fail if not using a patched version of k8s to executed the test.
 	// https://github.com/kubernetes/kubernetes/pull/110479
-	asserter.droppedTargetCount(t, 1)
+	// Succeeded pods are not added as endpoints of the service in K8s 1.27.0 or higher.
+	asserter.droppedTargetCount(t, 0)
+
+	// Active targets
+	asserter.activeTargetCount(t, 1)
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
`Test_EndpointsPhaseDropRule` test was failing because it was looking for a succeeded pod as an endpoint of a service but it was not found so the test was timing out. It looks like succeeded pods are no longer added as endpoints of a service starting in k8s 1.27 and higher. 

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests