### PR TITLE
feat: add additional global configs

### DIFF
--- a/internal/promcfg/config.go
+++ b/internal/promcfg/config.go
@@ -89,6 +89,18 @@ type GlobalConfig struct {
 	ScrapeTimeout time.Duration `yaml:"scrape_timeout,omitempty"`
 	// The labels to add to any timeseries that this Prometheus instance scrapes.
 	ExternalLabels map[string]string `yaml:"external_labels,omitempty"`
+	// An uncompressed response body larger than this many bytes will cause the scrape to fail.
+	BodySizeLimit int `yaml:"body_size_limit,omitempty"`
+	// Per-scrape limit on number of scraped samples that will be accepted.
+	SampleLimit int `yaml:"sample_limit,omitempty"`
+	// Per-scrape limit on number of labels that will be accepted for a sample.
+	LabelLimit int `yaml:"label_limit,omitempty"`
+	// Per-scrape limit on length of labels name that will be accepted for a sample.
+	LabelNameLengthLimit int `yaml:"label_name_length_limit,omitempty"`
+	// Per-scrape limit on length of labels value that will be accepted for a sample.
+	LabelValueLengthLimit int `yaml:"label_value_length_limit,omitempty"`
+	// Limit per scrape config on the number of targets dropped by relabeling that will be kept in memory. 0 means no limit.
+	KeepDroppedTargets int `yaml:"keep_dropped_targets,omitempty"`
 }
 
 // RelabelConfig defines relabel config rules which can be used in other configuration objects.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->

Adds the following config options to the config generator: 

see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/

```
  # An uncompressed response body larger than this many bytes will cause the
  # scrape to fail. 0 means no limit. Example: 100MB.
  # This is an experimental feature, this behaviour could
  # change or be removed in the future.
  [ body_size_limit: [<size>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#size) | default = 0 ]

  # Per-scrape limit on number of scraped samples that will be accepted.
  # If more than this number of samples are present after metric relabeling
  # the entire scrape will be treated as failed. 0 means no limit.
  [ sample_limit: [<int>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#int) | default = 0 ]

  # Per-scrape limit on number of labels that will be accepted for a sample. If
  # more than this number of labels are present post metric-relabeling, the
  # entire scrape will be treated as failed. 0 means no limit.
  [ label_limit: [<int>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#int) | default = 0 ]

  # Per-scrape limit on length of labels name that will be accepted for a sample.
  # If a label name is longer than this number post metric-relabeling, the entire
  # scrape will be treated as failed. 0 means no limit.
  [ label_name_length_limit: [<int>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#int) | default = 0 ]

  # Per-scrape limit on length of labels value that will be accepted for a sample.
  # If a label value is longer than this number post metric-relabeling, the
  # entire scrape will be treated as failed. 0 means no limit.
  [ label_value_length_limit: [<int>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#int) | default = 0 ]

  # Limit per scrape config on the number of targets dropped by relabeling
  # that will be kept in memory. 0 means no limit.
  [ keep_dropped_targets: [<int>](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#int) | default = 0 ]

```


## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests