### PR TITLE
feat: Add Kube 1.31 support and drop 1.26

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   # NOTICE that apart from this, the versions in the chart linter matrix needs to be bumped too.
-  LATEST_K8S_VERSION: 'v1.30.0'
+  LATEST_K8S_VERSION: 'v1.31.0'
 
 jobs:
   chart-lint:
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        kubernetes-version: ["v1.30.0", "v1.29.5", "v1.28.3", "v1.27.5", "v1.26.8"]
+        kubernetes-version: ["v1.31.0", "v1.30.0", "v1.29.5", "v1.28.3", "v1.27.5"]
     steps:
       - uses: azure/setup-helm@v4
         with:

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -9,6 +9,7 @@ on:
 env:
   # NOTICE that apart from this, the versions in the chart linter matrix needs to be bumped too.
   LATEST_K8S_VERSION: 'v1.31.0'
+  MINIKUBE_VERSION: 'v1.34.0'
 
 jobs:
   chart-lint:
@@ -66,7 +67,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.12.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          minikube version: v1.34.0
+          minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ matrix.kubernetes-version }}
           # default driver doesn't support 'eval $$(minikube docker-env)'.
           driver: docker
@@ -96,7 +97,7 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.12.0
         with:
-          minikube version: v1.34.0
+          minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ env.LATEST_K8S_VERSION }}
           # default driver doesn't support 'eval $$(minikube docker-env)'.
           driver: docker
@@ -143,7 +144,7 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.12.0
         with:
-          minikube version: v1.34.0
+          minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ env.LATEST_K8S_VERSION }}
           driver: docker
           github token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -63,10 +63,10 @@ jobs:
             exit 1
           fi
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.11.0
+        uses: manusa/actions-setup-minikube@v2.12.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          minikube version: v1.33.1
+          minikube version: v1.34.0
           kubernetes version: ${{ matrix.kubernetes-version }}
           # default driver doesn't support 'eval $$(minikube docker-env)'.
           driver: docker
@@ -94,9 +94,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.11.0
+        uses: manusa/actions-setup-minikube@v2.12.0
         with:
-          minikube version: v1.33.1
+          minikube version: v1.34.0
           kubernetes version: ${{ env.LATEST_K8S_VERSION }}
           # default driver doesn't support 'eval $$(minikube docker-env)'.
           driver: docker
@@ -141,9 +141,9 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.11.0
+        uses: manusa/actions-setup-minikube@v2.12.0
         with:
-          minikube version: v1.33.1
+          minikube version: v1.34.0
           kubernetes version: ${{ env.LATEST_K8S_VERSION }}
           driver: docker
           github token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-## v1.18.0 - 2024-10-17
-
-### 🚀 Enhancements
+### enhancement
 - Add 1.31 support and drop 1.26 @zeitlerc [#421](https://github.com/newrelic/newrelic-prometheus-configurator/pull/421)
 
 ## v1.17.4 - 2024-10-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+## v1.18.0 - 2024-10-17
+
+### 🚀 Enhancements
+- Add 1.31 support and drop 1.26 @zeitlerc [#421](https://github.com/newrelic/newrelic-prometheus-configurator/pull/421)
+
 ## v1.17.4 - 2024-10-07
 
 ### ⛓️ Dependencies

--- a/charts/internal/test-resources/templates/avalanche.yaml
+++ b/charts/internal/test-resources/templates/avalanche.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: avalanche
-        image: quay.io/prometheuscommunity/avalanche:main
+        image: quay.io/prometheuscommunity/avalanche:v0.6.0
         args:
         - --gauge-metric-count= {{- .Values.avalanche.metricCount }}
         - --label-count= {{- .Values.avalanche.labelCount }}

--- a/charts/internal/test-resources/templates/avalanche.yaml
+++ b/charts/internal/test-resources/templates/avalanche.yaml
@@ -21,7 +21,7 @@ spec:
       - name: avalanche
         image: quay.io/prometheuscommunity/avalanche:main
         args:
-        - --metric-count= {{- .Values.avalanche.metricCount }}
+        - --gauge-metric-count= {{- .Values.avalanche.metricCount }}
         - --label-count= {{- .Values.avalanche.labelCount }}
         - --series-count= {{- .Values.avalanche.seriesCount }}
         - --metricname-length= {{- .Values.avalanche.metricLength }}

--- a/test/integration/integration_kubernetes_test.go
+++ b/test/integration/integration_kubernetes_test.go
@@ -402,17 +402,26 @@ kubernetes:
 
 	asserter := newAsserter(ps)
 
+	// Active targets
 	asserter.activeTargetLabels(t, map[string]string{
 		"__meta_kubernetes_pod_name":     runningPod.Name,
 		"__meta_kubernetes_service_name": svc.Name,
 	})
+	asserter.activeTargetCount(t, 1)
 
-	// Failed Pods are not added as endpoints of the service in K8s.
+	// gsanchezgavier 9/13/2022: Failed Pods are not added as endpoints of the service in K8s.
 	// This could fail if not using a patched version of k8s to executed the test.
 	// https://github.com/kubernetes/kubernetes/pull/110479
-	// Succeeded pods are not added as endpoints of the service in K8s 1.27.0 or higher.
-	asserter.droppedTargetCount(t, 0)
+	// See also https://github.com/newrelic/newrelic-prometheus-configurator/pull/85
+	// svetlanabrennan 11/28/2023: Succeeded pods are not added as endpoints of the service in K8s 1.27.0 or higher.
+	// https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#urgent-upgrade-notes
+	// See also https://github.com/newrelic/newrelic-prometheus-configurator/pull/324
+	// czeitler 10/18/2024: Succeeded pods are once again added as endpoints in K8s 1.31.0 or higher.
+	// See also https://github.com/newrelic/newrelic-prometheus-configurator/pull/421
+	asserter.droppedTargetLabels(t, map[string]string{
+		"__meta_kubernetes_pod_name":     succeededPod.Name,
+		"__meta_kubernetes_service_name": svc.Name,
+	})
+	asserter.droppedTargetCount(t, 1)
 
-	// Active targets
-	asserter.activeTargetCount(t, 1)
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->

Test Kube 1.31 and drop 1.26

For `test/integration/integration_kubernetes_test.go`, I edited `Test_EndpointsPhaseDropRule` to expect the Succeeded pod in the dropped target labels.  Historically (before #324 and Kube 1.27.0), that was expected.  Apparently between Kube 1.27 and 1.30 inclusive, that was not expected.  Since PR #324 didn't explain why the change had to be made, I switched it back.

Pin avalanche (used by e2e testing) to a version to avoid the random breaking changes which happened in main.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [x] This change requires changes in testing:
  - [x] unit tests
  - [x] E2E tests