### PR TITLE
fix: update dockerfile apk command to actually upgrade packages

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,0 @@
-# Alpine 3.23.3 and golang-1.26-alpine (3.23) uses uses zlib 1.3.2-r0
-CVE-2026-22184
-CVE-2026-27171

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.23.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --upgrade && apk add --no-cache tini curl bind-tools
+RUN apk upgrade --no-cache && apk add --no-cache tini curl bind-tools
 
 COPY bin/prometheus-configurator-${TARGETOS}-${TARGETARCH} /
 


### PR DESCRIPTION
## Description
- `apk add --no-cache --upgrade` doesn't do anything without named packages. `apk upgrade --no-cache` will actually upgrade installed packages.
- Using .trivyignore for these vulnerabilities was hiding vulns from our repo trivy scanning. The alpine:3.23.3 image in Dockerhub has not been patched to use zlib 1.3.2-r0, although the change has been made in its package repositories.
- Using `apk upgrade` will upgrade zlib itself to use 1.3.2-r0 & resolve the vuln

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [x] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](https://github.com/newrelic/newrelic-prometheus-configurator/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests