### PR TITLE
Change Prometheus dockerhub repository to 'prom/prometheus'

### DIFF
--- a/charts/newrelic-prometheus-agent/values.yaml
+++ b/charts/newrelic-prometheus-agent/values.yaml
@@ -36,7 +36,7 @@ images:
   # @default -- See `values.yaml`
   prometheus:
     registry: ""
-    repository: prometheus/prometheus
+    repository: prom/prometheus
     pullPolicy: IfNotPresent
     # @default It defaults to `appVersion` in `Chart.yaml`.
     tag: ""


### PR DESCRIPTION
## Description
Correct the prometheus dockerhub path which is currently incorrect

## Type of change
default values change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](https://github.com/newrelic/newrelic-prometheus-configurator/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests