### PR TITLE
feat: Add more prometheus configuration options

### DIFF
--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   e2e-test-external:
-    name: Run E2E Tests (External Contribution)
+    name: Run E2E Tests
     # Do not run e2e tests if PR has skip-e2e label or if it's a non-forked repo (internal contribution)
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') && github.event.pull_request.head.repo.full_name != 'newrelic/newrelic-prometheus-configurator' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   e2e-test:
-    name: Run E2E Tests (Internal Contribution)
+    name: Run E2E Tests
     # Do not run e2e tests if PR has skip-e2e label or if it's from a forked repo (external contribution)
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') && github.event.pull_request.head.repo.full_name == 'newrelic/newrelic-prometheus-configurator' }}
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     - gocyclo
     - godot
     - goheader
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - govet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ## Unreleased
 
 ### enhancement
-- Adds new global configuration options @dbudziwojski [#594](https://github.com/newrelic/newrelic-prometheus-configurator/pull/594):
+- Adds new global configuration options @dbudziwojski @woehrl01 [#594](https://github.com/newrelic/newrelic-prometheus-configurator/pull/594):
   - rule_query_offset
   - query_log_file
   - scrape_failure_log_file 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ## Unreleased
 
 ### enhancement
-- Adds new global configuration options @dbudziwojski @woehrl01 [#594](https://github.com/newrelic/newrelic-prometheus-configurator/pull/594):
-  - rule_query_offset
-  - query_log_file
-  - scrape_failure_log_file 
-  - body_size_limit 
-  - sample_limit 
-  - label_limit
-  - label_name_length_limit
-  - label_value_length_limit
-  - target_limit
-  - keep_dropped_targets
-  - metric_name_validation_scheme
-  - extra_scrape_metrics
+- Adds new global configuration options: `rule_query_offset`, `query_log_file`, `scrape_failure_log_file`, `body_size_limit`, `sample_limit`, `label_limit`, `label_name_length_limit`, `label_value_length_limit`, `target_limit`, `keep_dropped_targets`, `metric_name_validation_scheme`, and `extra_scrape_metrics` @dbudziwojski @woehrl01 [#594](https://github.com/newrelic/newrelic-prometheus-configurator/pull/594):
 
 ## v2.11.3 - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### enhancement
+- Adds new global configuration options @dbudziwojski [#594](https://github.com/newrelic/newrelic-prometheus-configurator/pull/594):
+  - rule_query_offset
+  - query_log_file
+  - scrape_failure_log_file 
+  - body_size_limit 
+  - sample_limit 
+  - label_limit
+  - label_name_length_limit
+  - label_value_length_limit
+  - target_limit
+  - keep_dropped_targets
+  - metric_name_validation_scheme
+  - extra_scrape_metrics
+
 ## v2.11.3 - 2026-06-22
 
 ### ⛓️ Dependencies

--- a/internal/configurator/builder_test.go
+++ b/internal/configurator/builder_test.go
@@ -30,6 +30,7 @@ func TestBuilder(t *testing.T) { //nolint: tparallel
 		"endpoints-test",
 		"external-labels-test",
 		"filter-test",
+		"global-config-test",
 		"integration-filters-test",
 		"kubernetes-scrape-fields-test",
 		"kubernetes-scrape-fields-test-proxyfromenv",

--- a/internal/configurator/nr_config_test.go
+++ b/internal/configurator/nr_config_test.go
@@ -17,15 +17,29 @@ import (
 func TestNrConfig(t *testing.T) {
 	t.Parallel()
 
-	expected := testNrConfigExpectation(t, false)
-	nrConfigData, err := os.ReadFile("testdata/nr-config-test.yaml")
-	require.NoError(t, err)
-	checkNrConfig(t, expected, nrConfigData)
+	t.Run("with proxy URL", func(t *testing.T) {
+		t.Parallel()
+		expected := testNrConfigWithProxyURL(t)
+		nrConfigData, err := os.ReadFile("testdata/nr-config-test.yaml")
+		require.NoError(t, err)
+		checkNrConfig(t, expected, nrConfigData)
+	})
 
-	expected = testNrConfigExpectation(t, true)
-	nrConfigData, err = os.ReadFile("testdata/nr-config-test-proxyfromenv.yaml")
-	require.NoError(t, err)
-	checkNrConfig(t, expected, nrConfigData)
+	t.Run("with proxy from environment", func(t *testing.T) {
+		t.Parallel()
+		expected := testNrConfigWithProxyFromEnv(t)
+		nrConfigData, err := os.ReadFile("testdata/nr-config-test-proxyfromenv.yaml")
+		require.NoError(t, err)
+		checkNrConfig(t, expected, nrConfigData)
+	})
+
+	t.Run("with full global config", func(t *testing.T) {
+		t.Parallel()
+		expected := testNrConfigWithFullGlobalConfig(t)
+		nrConfigData, err := os.ReadFile("testdata/nr-config-test-globalconfig.yaml")
+		require.NoError(t, err)
+		checkNrConfig(t, expected, nrConfigData)
+	})
 }
 
 func checkNrConfig(t *testing.T, expected NrConfig, nrConfigData []byte) {
@@ -37,13 +51,11 @@ func checkNrConfig(t *testing.T, expected NrConfig, nrConfigData []byte) {
 	require.EqualValues(t, expected, nrConfig)
 }
 
-func testNrConfigExpectation(t *testing.T, useProxyFromEnv bool) NrConfig {
-	t.Helper()
-
+func baseRemoteWriteConfig() remotewrite.Config {
 	trueValue := true
 	falseValue := false
 
-	remoteWriteConfig := remotewrite.Config{
+	return remotewrite.Config{
 		DataSourceName: "data-source",
 		LicenseKey:     "nrLicenseKey",
 		Staging:        true,
@@ -75,23 +87,77 @@ func testNrConfigExpectation(t *testing.T, useProxyFromEnv bool) NrConfig {
 			},
 		},
 	}
+}
 
-	// Decide whether to use ProxyURL or ProxyFromEnvironment
-	if useProxyFromEnv {
-		remoteWriteConfig.ProxyFromEnvironment = true
-	} else {
-		remoteWriteConfig.ProxyURL = "http://proxy.url.to.use:1234"
+func baseGlobalConfig() promcfg.GlobalConfig {
+	return promcfg.GlobalConfig{
+		ScrapeInterval: time.Second * 60,
+		ScrapeTimeout:  time.Second,
+		ExternalLabels: map[string]string{
+			"one":   "two",
+			"three": "four",
+		},
 	}
+}
+
+func testNrConfigWithProxyURL(t *testing.T) NrConfig {
+	t.Helper()
+
+	remoteWriteConfig := baseRemoteWriteConfig()
+	remoteWriteConfig.ProxyURL = "http://proxy.url.to.use:1234"
 
 	return NrConfig{
-		Common: promcfg.GlobalConfig{
-			ScrapeInterval: time.Second * 60,
-			ScrapeTimeout:  time.Second,
-			ExternalLabels: map[string]string{
-				"one":   "two",
-				"three": "four",
+		Common:      baseGlobalConfig(),
+		RemoteWrite: remoteWriteConfig,
+		ExtraRemoteWrite: []RawPromConfig{
+			map[string]any{
+				"url": "https://extra.prometheus.remote.write",
 			},
 		},
+	}
+}
+
+func testNrConfigWithProxyFromEnv(t *testing.T) NrConfig {
+	t.Helper()
+
+	remoteWriteConfig := baseRemoteWriteConfig()
+	remoteWriteConfig.ProxyFromEnvironment = true
+
+	return NrConfig{
+		Common:      baseGlobalConfig(),
+		RemoteWrite: remoteWriteConfig,
+		ExtraRemoteWrite: []RawPromConfig{
+			map[string]any{
+				"url": "https://extra.prometheus.remote.write",
+			},
+		},
+	}
+}
+
+func testNrConfigWithFullGlobalConfig(t *testing.T) NrConfig {
+	t.Helper()
+
+	remoteWriteConfig := baseRemoteWriteConfig()
+	remoteWriteConfig.ProxyURL = "http://proxy.url.to.use:1234"
+
+	globalConfig := baseGlobalConfig()
+	globalConfig.ScrapeProtocols = []string{"PrometheusProto", "OpenMetricsText1.0.0"}
+	globalConfig.EvaluationInterval = 2 * time.Minute
+	globalConfig.RuleQueryOffset = 5 * time.Second
+	globalConfig.QueryLogFile = "/var/log/prometheus/query.log"
+	globalConfig.ScrapeFailureLogFile = "/var/log/prometheus/scrape-failures.log"
+	globalConfig.BodySizeLimit = 10 * 1024 * 1024 // 10MiB
+	globalConfig.SampleLimit = 1000
+	globalConfig.LabelLimit = 50
+	globalConfig.LabelNameLengthLimit = 200
+	globalConfig.LabelValueLengthLimit = 500
+	globalConfig.TargetLimit = 100
+	globalConfig.KeepDroppedTargets = 10
+	globalConfig.MetricNameValidationScheme = "utf8"
+	globalConfig.ExtraScrapeMetrics = true
+
+	return NrConfig{
+		Common:      globalConfig,
 		RemoteWrite: remoteWriteConfig,
 		ExtraRemoteWrite: []RawPromConfig{
 			map[string]any{

--- a/internal/configurator/nr_config_test.go
+++ b/internal/configurator/nr_config_test.go
@@ -100,6 +100,14 @@ func baseGlobalConfig() promcfg.GlobalConfig {
 	}
 }
 
+func baseExtraRemoteWriteConfig() []RawPromConfig {
+	return []RawPromConfig{
+		map[string]any{
+			"url": "https://extra.prometheus.remote.write",
+		},
+	}
+}
+
 func testNrConfigWithProxyURL(t *testing.T) NrConfig {
 	t.Helper()
 
@@ -107,13 +115,9 @@ func testNrConfigWithProxyURL(t *testing.T) NrConfig {
 	remoteWriteConfig.ProxyURL = "http://proxy.url.to.use:1234"
 
 	return NrConfig{
-		Common:      baseGlobalConfig(),
-		RemoteWrite: remoteWriteConfig,
-		ExtraRemoteWrite: []RawPromConfig{
-			map[string]any{
-				"url": "https://extra.prometheus.remote.write",
-			},
-		},
+		Common:           baseGlobalConfig(),
+		RemoteWrite:      remoteWriteConfig,
+		ExtraRemoteWrite: baseExtraRemoteWriteConfig(),
 	}
 }
 
@@ -124,13 +128,9 @@ func testNrConfigWithProxyFromEnv(t *testing.T) NrConfig {
 	remoteWriteConfig.ProxyFromEnvironment = true
 
 	return NrConfig{
-		Common:      baseGlobalConfig(),
-		RemoteWrite: remoteWriteConfig,
-		ExtraRemoteWrite: []RawPromConfig{
-			map[string]any{
-				"url": "https://extra.prometheus.remote.write",
-			},
-		},
+		Common:           baseGlobalConfig(),
+		RemoteWrite:      remoteWriteConfig,
+		ExtraRemoteWrite: baseExtraRemoteWriteConfig(),
 	}
 }
 
@@ -157,12 +157,8 @@ func testNrConfigWithFullGlobalConfig(t *testing.T) NrConfig {
 	globalConfig.ExtraScrapeMetrics = true
 
 	return NrConfig{
-		Common:      globalConfig,
-		RemoteWrite: remoteWriteConfig,
-		ExtraRemoteWrite: []RawPromConfig{
-			map[string]any{
-				"url": "https://extra.prometheus.remote.write",
-			},
-		},
+		Common:           globalConfig,
+		RemoteWrite:      remoteWriteConfig,
+		ExtraRemoteWrite: baseExtraRemoteWriteConfig(),
 	}
 }

--- a/internal/configurator/testdata/global-config-test.expected.yaml
+++ b/internal/configurator/testdata/global-config-test.expected.yaml
@@ -1,0 +1,26 @@
+remote_write:
+  - name: newrelic_rw
+    url: https://metric-api.newrelic.com/prometheus/v1/write?collector_name=prometheus-agent&prometheus_server=test-source
+    authorization:
+      credentials: test-license-key
+global:
+  scrape_interval: 30s
+  scrape_timeout: 10s
+  scrape_protocols:
+    - PrometheusProto
+    - OpenMetricsText1.0.0
+  evaluation_interval: 1m0s
+  rule_query_offset: 10s
+  external_labels:
+    cluster: test-cluster
+  query_log_file: /var/log/queries.log
+  scrape_failure_log_file: /var/log/scrape-failures.log
+  body_size_limit: 5MiB
+  sample_limit: 500
+  label_limit: 30
+  label_name_length_limit: 100
+  label_value_length_limit: 250
+  target_limit: 50
+  keep_dropped_targets: 5
+  metric_name_validation_scheme: utf8
+  extra_scrape_metrics: true

--- a/internal/configurator/testdata/global-config-test.yaml
+++ b/internal/configurator/testdata/global-config-test.yaml
@@ -1,0 +1,25 @@
+common:
+  external_labels:
+    cluster: test-cluster
+  scrape_interval: 30s
+  scrape_timeout: 10s
+  scrape_protocols:
+    - PrometheusProto
+    - OpenMetricsText1.0.0
+  evaluation_interval: 1m
+  rule_query_offset: 10s
+  query_log_file: /var/log/queries.log
+  scrape_failure_log_file: /var/log/scrape-failures.log
+  body_size_limit: 5MiB
+  sample_limit: 500
+  label_limit: 30
+  label_name_length_limit: 100
+  label_value_length_limit: 250
+  target_limit: 50
+  keep_dropped_targets: 5
+  metric_name_validation_scheme: utf8
+  extra_scrape_metrics: true
+
+newrelic_remote_write:
+  license_key: test-license-key
+  data_source_name: test-source

--- a/internal/configurator/testdata/nr-config-test-globalconfig.yaml
+++ b/internal/configurator/testdata/nr-config-test-globalconfig.yaml
@@ -4,6 +4,22 @@ common:
     three: four
   scrape_interval: 1m
   scrape_timeout: 1s
+  scrape_protocols:
+    - PrometheusProto
+    - OpenMetricsText1.0.0
+  evaluation_interval: 2m
+  rule_query_offset: 5s
+  query_log_file: /var/log/prometheus/query.log
+  scrape_failure_log_file: /var/log/prometheus/scrape-failures.log
+  body_size_limit: 10MiB
+  sample_limit: 1000
+  label_limit: 50
+  label_name_length_limit: 200
+  label_value_length_limit: 500
+  target_limit: 100
+  keep_dropped_targets: 10
+  metric_name_validation_scheme: utf8
+  extra_scrape_metrics: true
 
 newrelic_remote_write:
   data_source_name: data-source

--- a/internal/configurator/testdata/nr-config-test-proxyfromenv.yaml
+++ b/internal/configurator/testdata/nr-config-test-proxyfromenv.yaml
@@ -4,7 +4,6 @@ common:
     three: four
   scrape_interval: 1m
   scrape_timeout: 1s
-  query_log_file: none
 
 newrelic_remote_write:
   data_source_name: data-source

--- a/internal/promcfg/config.go
+++ b/internal/promcfg/config.go
@@ -104,7 +104,7 @@ type GlobalConfig struct {
 	// File to which scrape failures are logged.
 	ScrapeFailureLogFile string `yaml:"scrape_failure_log_file,omitempty"`
 	// An uncompressed response body larger than this many bytes will cause the scrape to fail.
-	BodySizeLimit uint `yaml:"body_size_limit,omitempty"`
+	BodySizeLimit units.Base2Bytes `yaml:"body_size_limit,omitempty"`
 	// Per-scrape limit on number of scraped samples that will be accepted.
 	SampleLimit uint `yaml:"sample_limit,omitempty"`
 	// Per-scrape limit on number of labels that will be accepted for a sample.

--- a/internal/promcfg/config.go
+++ b/internal/promcfg/config.go
@@ -90,8 +90,37 @@ type GlobalConfig struct {
 	ScrapeInterval time.Duration `yaml:"scrape_interval,omitempty"`
 	// The default timeout when scraping targets.
 	ScrapeTimeout time.Duration `yaml:"scrape_timeout,omitempty"`
+	// The protocols to negotiate during a scrape with the client.
+	ScrapeProtocols []string `yaml:"scrape_protocols,omitempty"`
+	// How frequently to evaluate rules.
+	EvaluationInterval time.Duration `yaml:"evaluation_interval,omitempty"`
+	// Offset the rule evaluation timestamp of this particular group by the specified duration into the past to ensure
+	// the underlying metrics have been received.
+	RuleQueryOffset time.Duration `yaml:"rule_query_offset,omitempty"`
 	// The labels to add to any timeseries that this Prometheus instance scrapes.
 	ExternalLabels map[string]string `yaml:"external_labels,omitempty"`
+	// File to which PromQL queries are logged.
+	QueryLogFile string `yaml:"query_log_file,omitempty"`
+	// File to which scrape failures are logged.
+	ScrapeFailureLogFile string `yaml:"scrape_failure_log_file,omitempty"`
+	// An uncompressed response body larger than this many bytes will cause the scrape to fail.
+	BodySizeLimit uint `yaml:"body_size_limit,omitempty"`
+	// Per-scrape limit on number of scraped samples that will be accepted.
+	SampleLimit uint `yaml:"sample_limit,omitempty"`
+	// Per-scrape limit on number of labels that will be accepted for a sample.
+	LabelLimit uint `yaml:"label_limit,omitempty"`
+	// Per-scrape limit on length of labels name that will be accepted for a sample.
+	LabelNameLengthLimit uint `yaml:"label_name_length_limit,omitempty"`
+	// Per-scrape limit on length of labels value that will be accepted for a sample.
+	LabelValueLengthLimit uint `yaml:"label_value_length_limit,omitempty"`
+	// Limit per scrape config on number of unique targets that will be accepted.
+	TargetLimit uint `yaml:"target_limit,omitempty"`
+	// Limit per scrape config on the number of targets dropped by relabeling that will be kept in memory. 0 means no limit.
+	KeepDroppedTargets uint `yaml:"keep_dropped_targets,omitempty"`
+	// Specifies the validation scheme for metric and label names.
+	MetricNameValidationScheme string `yaml:"metric_name_validation_scheme,omitempty"`
+	// When enabled, Prometheus stores additional time series for each scrape: scrape_timeout_seconds, scrape_sample_limit, and scrape_body_size_bytes.
+	ExtraScrapeMetrics bool `yaml:"extra_scrape_metrics,omitempty"`
 }
 
 // RelabelConfig defines relabel config rules which can be used in other configuration objects.


### PR DESCRIPTION
## Description
Adds the following global configuration options:
- rule_query_offset
- query_log_file
- scrape_failure_log_file
- body_size_limit
- sample_limit
- label_limit
- label_name_length_limit
- label_value_length_limit
- target_limit
- keep_dropped_targets
- metric_name_validation_scheme
- extra_scrape_metrics

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](https://github.com/newrelic/newrelic-prometheus-configurator/blob/main/CONTRIBUTING.md#pull-requests)
- [X] Documentation has been updated
- [X] This change requires changes in testing:
  - [X] unit tests
  - [X] E2E tests